### PR TITLE
Upgrade to latest fxhash project SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ etc.)
 A tiny, fully documented throwaway example sketch is included, illustrating the
 following:
 
--   Overall project structure & build commands
--   FXhash related setup
--   Static & dynamic configuration and state (re)initialization/handling
--   FXhash PRNG wrapper & utilities
--   Canvas & SVG conversion/export/download
--   2D geometry creation, transformation & drawing
--   Basic vector algebra example usage
+- Overall project structure & build commands
+- FXhash related setup
+- Static & dynamic configuration and state (re)initialization/handling
+- FXhash PRNG wrapper & utilities
+- Canvas & SVG conversion/export/download
+- 2D geometry creation, transformation & drawing
+- Basic vector algebra example usage
 
 The best way is to [dive into the source
 code](https://github.com/thi-ng/tpl-umbrella-fxhash/blob/main/src/) and start
@@ -51,7 +51,7 @@ concepts used...
 ### thi.ng/umbrella packages used
 
 Note: Most of these packages list here each have a much wider remit than
-utilized here in this small demo project scaffolding...
+utilized here in this small demo project scaffolding... 
 
 Depending on which parts of the template you'll be keeping for your own
 purposes, some of these packages can be safely removed. Feel free though to
@@ -59,7 +59,7 @@ check out some of the other 165+ projects in the
 [thi.ng/umbrella](https://thi.ng/umbrella) monorepo (**NOT a framework!**)...
 
 | Package                                               | Role in this template                         |
-| ----------------------------------------------------- | --------------------------------------------- |
+|-------------------------------------------------------|-----------------------------------------------|
 | [@thi.ng/adapt-dpi](https://thi.ng/adapt-dpi)         | Configure canvas for HDPI displays            |
 | [@thi.ng/api](https://thi.ng/api)                     | Useful common & shared type definitions       |
 | [@thi.ng/date](https://thi.ng/date)                   | Timestamp formatter for media downloads       |
@@ -72,6 +72,7 @@ check out some of the other 165+ projects in the
 | [@thi.ng/resolve-map](https://thi.ng/resolve-map)     | Graphbased config & state initialization      |
 | [@thi.ng/transducers](https://thi.ng/transducers)     | Iteration & data transformation               |
 | [@thi.ng/vectors](https://thi.ng/vectors)             | nD Vector algebra                             |
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ ensuring an altogether great & speedy workflow with minimal fuzz.
 hybrid projects using TypeScript, [Zig](https://ziglang.org) and
 [WebAssembly](https://webassembly.org/)...)
 
+**The template is currently using the following version of the fxhash project sdk:** [61ac228c](https://github.com/fxhash/fxhash-package/commit/61ac228ce103fcea2e28c365f0facd38f0b8479f)
+
 ### Framework agnostic
 
 Even though several packages from the [thi.ng/umbrella](https://thi.ng/umbrella)
@@ -33,13 +35,13 @@ etc.)
 A tiny, fully documented throwaway example sketch is included, illustrating the
 following:
 
-- Overall project structure & build commands
-- FXhash related setup
-- Static & dynamic configuration and state (re)initialization/handling
-- FXhash PRNG wrapper & utilities
-- Canvas & SVG conversion/export/download
-- 2D geometry creation, transformation & drawing
-- Basic vector algebra example usage
+-   Overall project structure & build commands
+-   FXhash related setup
+-   Static & dynamic configuration and state (re)initialization/handling
+-   FXhash PRNG wrapper & utilities
+-   Canvas & SVG conversion/export/download
+-   2D geometry creation, transformation & drawing
+-   Basic vector algebra example usage
 
 The best way is to [dive into the source
 code](https://github.com/thi-ng/tpl-umbrella-fxhash/blob/main/src/) and start
@@ -49,7 +51,7 @@ concepts used...
 ### thi.ng/umbrella packages used
 
 Note: Most of these packages list here each have a much wider remit than
-utilized here in this small demo project scaffolding... 
+utilized here in this small demo project scaffolding...
 
 Depending on which parts of the template you'll be keeping for your own
 purposes, some of these packages can be safely removed. Feel free though to
@@ -57,7 +59,7 @@ check out some of the other 165+ projects in the
 [thi.ng/umbrella](https://thi.ng/umbrella) monorepo (**NOT a framework!**)...
 
 | Package                                               | Role in this template                         |
-|-------------------------------------------------------|-----------------------------------------------|
+| ----------------------------------------------------- | --------------------------------------------- |
 | [@thi.ng/adapt-dpi](https://thi.ng/adapt-dpi)         | Configure canvas for HDPI displays            |
 | [@thi.ng/api](https://thi.ng/api)                     | Useful common & shared type definitions       |
 | [@thi.ng/date](https://thi.ng/date)                   | Timestamp formatter for media downloads       |
@@ -70,7 +72,6 @@ check out some of the other 165+ projects in the
 | [@thi.ng/resolve-map](https://thi.ng/resolve-map)     | Graphbased config & state initialization      |
 | [@thi.ng/transducers](https://thi.ng/transducers)     | Iteration & data transformation               |
 | [@thi.ng/vectors](https://thi.ng/vectors)             | nD Vector algebra                             |
-
 
 ## Getting started
 

--- a/index.html
+++ b/index.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-		/>
-		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <head>
+        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+        />
+        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 		<script src="/fxhash.js"></script>
-		<title>TODO</title>
-		<style>
-			body {
-				height: 100vh;
-				overflow: hidden;
-				display: grid;
-				grid-template-columns: 1fr 1fr 1fr;
-				grid-template-rows: 1fr 1fr 1fr;
-				margin: 0;
-			}
-			#app {
-				grid-column-start: 2;
-				grid-row-start: 2;
-			}
-		</style>
-	</head>
-	<body>
-		<div id="app"></div>
-		<script type="module" src="/src/index.ts"></script>
-	</body>
+        <title>TODO</title>
+        <style>
+            body {
+                height: 100vh;
+                overflow: hidden;
+                display: grid;
+                grid-template-columns: 1fr 1fr 1fr;
+                grid-template-rows: 1fr 1fr 1fr;
+                margin: 0;
+            }
+            #app {
+                grid-column-start: 2;
+                grid-row-start: 2;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script type="module" src="/src/index.ts"></script>
+    </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,61 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-        />
-        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <title>TODO</title>
-        <!-- prettier-ignore -->
-        <script id="fxhash-snippet">
-            //---- do not edit the following code (you can indent as you wish)
-            let alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
-            var fxhash = "oo" + Array(49).fill(0).map(_=>alphabet[(Math.random()*alphabet.length)|0]).join('')
-            let b58dec = str=>[...str].reduce((p,c)=>p*alphabet.length+alphabet.indexOf(c)|0, 0)
-            let fxhashTrunc = fxhash.slice(2)
-            let regex = new RegExp(".{" + ((fxhashTrunc.length/4)|0) + "}", 'g')
-            let hashes = fxhashTrunc.match(regex).map(h => b58dec(h))
-            let sfc32 = (a, b, c, d) => {
-                return () => {
-                a |= 0; b |= 0; c |= 0; d |= 0
-                var t = (a + b | 0) + d | 0
-                d = d + 1 | 0
-                a = b ^ b >>> 9
-                b = c + (c << 3) | 0
-                c = c << 21 | c >>> 11
-                c = c + t | 0
-                return (t >>> 0) / 4294967296
-                }
-            }
-            var fxrand = sfc32(...hashes)
-            // true if preview mode active, false otherwise
-            // you can append preview=1 to the URL to simulate preview active
-            var isFxpreview = new URLSearchParams(window.location.search).get('preview') === "1"
-            // call this method to trigger the preview
-            function fxpreview() {
-                console.log("fxhash: TRIGGER PREVIEW");
-            }
-            //---- /do not edit the following code
-        </script>
-        <style>
-            body {
-                height: 100vh;
-                overflow: hidden;
-                display: grid;
-                grid-template-columns: 1fr 1fr 1fr;
-                grid-template-rows: 1fr 1fr 1fr;
-                margin: 0;
-            }
-            #app {
-                grid-column-start: 2;
-                grid-row-start: 2;
-            }
-        </style>
-    </head>
-    <body>
-        <div id="app"></div>
-        <script type="module" src="/src/index.ts"></script>
-    </body>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+		/>
+		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<script src="/fxhash.js"></script>
+		<title>TODO</title>
+		<style>
+			body {
+				height: 100vh;
+				overflow: hidden;
+				display: grid;
+				grid-template-columns: 1fr 1fr 1fr;
+				grid-template-rows: 1fr 1fr 1fr;
+				margin: 0;
+			}
+			#app {
+				grid-column-start: 2;
+				grid-row-start: 2;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/index.ts"></script>
+	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@thi.ng/geom": "^5.2.14",
 		"@thi.ng/hiccup-canvas": "^2.4.4",
 		"@thi.ng/pixel": "^4.3.1",
-		"@thi.ng/random-fxhash": "^0.3.17",
+		"@thi.ng/random-fxhash": "^0.3.18",
 		"@thi.ng/resolve-map": "^7.1.40",
 		"@thi.ng/transducers": "^8.8.7",
 		"@thi.ng/vectors": "^7.8.1"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
 	"type": "module",
 	"scripts": {
 		"start": "vite --open --host",
-		"build": "tsc && vite build --base='./'",
+		"build": "tsc && vite build --base=./",
 		"preview": "vite preview --open --host",
-		"bundle": "yarn build && (cd dist && zip fxh-$(date +%s).zip assets/*.* index.html)"
+		"bundle": "yarn build && (cd dist && zip fxh-$(date +%s).zip assets/*.* index.html fxhash.js)"
 	},
 	"devDependencies": {
 		"@types/node": "20.8.10",

--- a/public/fxhash.js
+++ b/public/fxhash.js
@@ -1,628 +1,575 @@
 "use strict";
 (() => {
-	// src/sdk/math.ts
-	var alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
-	function b58dec(str) {
-		return [...str].reduce(function (p, c) {
-			return (p * alphabet.length + alphabet.indexOf(c)) | 0;
-		}, 0);
-	}
-	function sfc32(seed) {
-		let a = seed[0] | 0;
-		let b = seed[1] | 0;
-		let c = seed[2] | 0;
-		let d = seed[3] | 0;
-		return function () {
-			a |= 0;
-			b |= 0;
-			c |= 0;
-			d |= 0;
-			const t = (((a + b) | 0) + d) | 0;
-			d = (d + 1) | 0;
-			a = b ^ (b >>> 9);
-			b = (c + (c << 3)) | 0;
-			c = (c << 21) | (c >>> 11);
-			c = (c + t) | 0;
-			return (t >>> 0) / 4294967296;
-		};
-	}
-	function matcher(str, start) {
-		return str
-			.slice(start)
-			.match(new RegExp(".{" + ((str.length - start) >> 2) + "}", "g"))
-			.map(function (substring) {
-				return b58dec(substring);
-			});
-	}
-	function getRandomHash(n) {
-		return Array(n)
-			.fill(0)
-			.map(function (_) {
-				return alphabet[(Math.random() * alphabet.length) | 0];
-			})
-			.join("");
-	}
-	function createFxRandom(fxhash, start) {
-		return sfc32(matcher(fxhash, start));
-	}
+  // src/sdk/math.ts
+  var alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
+  function b58dec(str) {
+    return [...str].reduce(function(p, c) {
+      return p * alphabet.length + alphabet.indexOf(c) | 0;
+    }, 0);
+  }
+  function sfc32(seed) {
+    let a = seed[0] | 0;
+    let b = seed[1] | 0;
+    let c = seed[2] | 0;
+    let d = seed[3] | 0;
+    return function() {
+      a |= 0;
+      b |= 0;
+      c |= 0;
+      d |= 0;
+      const t = (a + b | 0) + d | 0;
+      d = d + 1 | 0;
+      a = b ^ b >>> 9;
+      b = c + (c << 3) | 0;
+      c = c << 21 | c >>> 11;
+      c = c + t | 0;
+      return (t >>> 0) / 4294967296;
+    };
+  }
+  function matcher(str, start) {
+    return str.slice(start).match(new RegExp(".{" + (str.length - start >> 2) + "}", "g")).map(function(substring) {
+      return b58dec(substring);
+    });
+  }
+  function getRandomHash(n) {
+    return Array(n).fill(0).map(function(_) {
+      return alphabet[Math.random() * alphabet.length | 0];
+    }).join("");
+  }
+  function createFxRandom(fxhash, start) {
+    return sfc32(matcher(fxhash, start));
+  }
 
-	// ../fxhash-params/dist/chunk-FZWZHHQ2.js
-	function completeHexColor(hexCode) {
-		let hex = hexCode.replace("#", "");
-		if (hex.length === 6) {
-			hex = `${hex}ff`;
-		}
-		if (hex.length === 3) {
-			hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}ff`;
-		}
-		return hex;
-	}
-	var stringToHex = function (s) {
-		let rtn = "";
-		for (let i = 0; i < s.length; i++) {
-			rtn += s.charCodeAt(i).toString(16).padStart(4, "0");
-		}
-		return rtn;
-	};
-	var hexToString = function (h) {
-		const hx = h.match(/.{1,4}/g) || [];
-		let rtn = "";
-		for (let i = 0; i < hx.length; i++) {
-			const int = parseInt(hx[i], 16);
-			if (int === 0) break;
-			rtn += String.fromCharCode(int);
-		}
-		return rtn;
-	};
-	var MIN_SAFE_INT64 = BigInt("-9223372036854775808");
-	var MAX_SAFE_INT64 = BigInt("9223372036854775807");
-	var ParameterProcessors = {
-		number: {
-			serialize: (input) => {
-				const view = new DataView(new ArrayBuffer(8));
-				view.setFloat64(0, input);
-				return view.getBigUint64(0).toString(16).padStart(16, "0");
-			},
-			deserialize: (input) => {
-				const view = new DataView(new ArrayBuffer(8));
-				for (let i = 0; i < 8; i++) {
-					view.setUint8(
-						i,
-						parseInt(input.substring(i * 2, i * 2 + 2), 16)
-					);
-				}
-				return view.getFloat64(0);
-			},
-			bytesLength: () => 8,
-			constrain: (value, definition) => {
-				let min = Number.MIN_SAFE_INTEGER;
-				if (typeof definition.options?.min !== "undefined")
-					min = Number(definition.options.min);
-				let max = Number.MAX_SAFE_INTEGER;
-				if (typeof definition.options?.max !== "undefined")
-					max = Number(definition.options.max);
-				max = Math.min(max, Number.MAX_SAFE_INTEGER);
-				min = Math.max(min, Number.MIN_SAFE_INTEGER);
-				const v = Math.min(Math.max(value, min), max);
-				if (definition?.options?.step) {
-					const t = 1 / definition?.options?.step;
-					return Math.round(v * t) / t;
-				}
-				return v;
-			},
-			random: (definition) => {
-				let min = Number.MIN_SAFE_INTEGER;
-				if (typeof definition.options?.min !== "undefined")
-					min = Number(definition.options.min);
-				let max = Number.MAX_SAFE_INTEGER;
-				if (typeof definition.options?.max !== "undefined")
-					max = Number(definition.options.max);
-				max = Math.min(max, Number.MAX_SAFE_INTEGER);
-				min = Math.max(min, Number.MIN_SAFE_INTEGER);
-				const v = Math.random() * (max - min) + min;
-				if (definition?.options?.step) {
-					const t = 1 / definition?.options?.step;
-					return Math.round(v * t) / t;
-				}
-				return v;
-			},
-		},
-		bigint: {
-			serialize: (input) => {
-				const view = new DataView(new ArrayBuffer(8));
-				view.setBigInt64(0, BigInt(input));
-				return view.getBigUint64(0).toString(16).padStart(16, "0");
-			},
-			deserialize: (input) => {
-				const view = new DataView(new ArrayBuffer(8));
-				for (let i = 0; i < 8; i++) {
-					view.setUint8(
-						i,
-						parseInt(input.substring(i * 2, i * 2 + 2), 16)
-					);
-				}
-				return view.getBigInt64(0);
-			},
-			bytesLength: () => 8,
-			random: (definition) => {
-				let min = MIN_SAFE_INT64;
-				let max = MAX_SAFE_INT64;
-				if (typeof definition.options?.min !== "undefined")
-					min = BigInt(definition.options.min);
-				if (typeof definition.options?.max !== "undefined")
-					max = BigInt(definition.options.max);
-				const range = max - min;
-				const bits = range.toString(2).length;
-				let random;
-				do {
-					random = BigInt(
-						"0b" +
-							Array.from(
-								crypto.getRandomValues(
-									new Uint8Array(Math.ceil(bits / 8))
-								)
-							)
-								.map((b) => b.toString(2).padStart(8, "0"))
-								.join("")
-					);
-				} while (random > range);
-				return random + min;
-			},
-		},
-		boolean: {
-			serialize: (input) => {
-				return typeof input === "boolean"
-					? input
-						? "01"
-						: "00"
-					: typeof input === "string"
-					? input === "true"
-						? "01"
-						: "00"
-					: "00";
-			},
-			deserialize: (input) => {
-				return input === "00" ? false : true;
-			},
-			bytesLength: () => 1,
-			random: () => Math.random() < 0.5,
-		},
-		color: {
-			serialize: (input) => {
-				return completeHexColor(input);
-			},
-			deserialize: (input) => {
-				return input;
-			},
-			bytesLength: () => 4,
-			transform: (input) => {
-				const color = completeHexColor(input);
-				const r = parseInt(color.slice(0, 2), 16);
-				const g = parseInt(color.slice(2, 4), 16);
-				const b = parseInt(color.slice(4, 6), 16);
-				const a = parseInt(color.slice(6, 8), 16);
-				return {
-					hex: {
-						rgb: "#" + input.slice(0, 6),
-						rgba: "#" + input,
-					},
-					obj: {
-						rgb: { r, g, b },
-						rgba: { r, g, b, a },
-					},
-					arr: {
-						rgb: [r, g, b],
-						rgba: [r, g, b, a],
-					},
-				};
-			},
-			constrain: (value) => {
-				const hex = value.replace("#", "");
-				return hex.slice(0, 8).padEnd(8, "f");
-			},
-			random: () =>
-				`${[...Array(8)]
-					.map(() => Math.floor(Math.random() * 16).toString(16))
-					.join("")}`,
-		},
-		string: {
-			serialize: (input, def) => {
-				if (!def.version) {
-					let hex2 = stringToHex(input.substring(0, 64));
-					hex2 = hex2.padEnd(64 * 4, "0");
-					return hex2;
-				}
-				let max = 64;
-				if (typeof def.options?.maxLength !== "undefined")
-					max = Number(def.options.maxLength);
-				let hex = stringToHex(input.substring(0, max));
-				hex = hex.padEnd(max * 4, "0");
-				return hex;
-			},
-			deserialize: (input) => {
-				return hexToString(input);
-			},
-			bytesLength: (def) => {
-				if (!def.version) {
-					return 64 * 2;
-				}
-				if (typeof def.options?.maxLength !== "undefined")
-					return Number(def.options.maxLength) * 2;
-				return 64 * 2;
-			},
-			random: (definition) => {
-				let min = 0;
-				if (typeof definition.options?.minLength !== "undefined")
-					min = definition.options.minLength;
-				let max = 64;
-				if (typeof definition.options?.maxLength !== "undefined")
-					max = definition.options.maxLength;
-				const length = Math.round(Math.random() * (max - min) + min);
-				return [...Array(length)]
-					.map((i) => (~~(Math.random() * 36)).toString(36))
-					.join("");
-			},
-			constrain: (value, definition) => {
-				let min = 0;
-				if (typeof definition.options?.minLength !== "undefined")
-					min = definition.options.minLength;
-				let max = 64;
-				if (typeof definition.options?.maxLength !== "undefined")
-					max = definition.options.maxLength;
-				const v = value.slice(0, max);
-				if (v.length < min) {
-					return v.padEnd(min);
-				}
-				return v;
-			},
-		},
-		bytes: {
-			serialize: (input, def) => {
-				return Array.from(input)
-					.map((i) => i.toString(16).padStart(2, "0"))
-					.join("");
-			},
-			deserialize: (input, def) => {
-				const len = input.length / 2;
-				const uint8 = new Uint8Array(len);
-				let idx;
-				for (let i = 0; i < len; i++) {
-					idx = i * 2;
-					uint8[i] = parseInt(`${input[idx]}${input[idx + 1]}`, 16);
-				}
-				return uint8;
-			},
-			bytesLength: (def) => def.options.length,
-			random: (def) => {
-				const len = def.options?.length || 0;
-				const uint8 = new Uint8Array(len);
-				for (let i = 0; i < len; i++) {
-					uint8[i] = (Math.random() * 255) | 0;
-				}
-				return uint8;
-			},
-		},
-		select: {
-			serialize: (input, def) => {
-				return Math.min(255, def.options?.options?.indexOf(input) || 0)
-					.toString(16)
-					.padStart(2, "0");
-			},
-			deserialize: (input, def) => {
-				const idx = parseInt(input, 16);
-				return (
-					def.options?.options?.[idx] ||
-					def.options?.options?.[0] ||
-					""
-				);
-			},
-			bytesLength: () => 1,
-			// index between 0 and 255
-			constrain: (value, definition) => {
-				if (definition.options.options.includes(value)) {
-					return value;
-				}
-				return definition.options.options[0];
-			},
-			random: (definition) => {
-				const index = Math.round(
-					Math.random() * (definition.options.options.length - 1) + 0
-				);
-				return definition?.options?.options[index];
-			},
-		},
-	};
-	function serializeParams(params, definition) {
-		let bytes = "";
-		if (!definition) return bytes;
-		for (const def of definition) {
-			const { id, type } = def;
-			const processor = ParameterProcessors[type];
-			const v = params[id];
-			const val =
-				typeof v !== "undefined"
-					? v
-					: typeof def.default !== "undefined"
-					? def.default
-					: processor.random(def);
-			const serialized = processor.serialize(val, def);
-			bytes += serialized;
-		}
-		return bytes;
-	}
-	function deserializeParams(bytes, definition, options) {
-		const params = {};
-		for (const def of definition) {
-			const processor = ParameterProcessors[def.type];
-			const transformer =
-				options.withTransform &&
-				processor[options.transformType || "transform"];
-			if (!bytes) {
-				let v;
-				if (typeof def.default === "undefined")
-					v = processor.random(def);
-				else v = def.default;
-				params[def.id] = transformer ? transformer(v, def) : v;
-				continue;
-			}
-			const bytesLen = processor.bytesLength(def);
-			const valueBytes = bytes.substring(0, bytesLen * 2);
-			bytes = bytes.substring(bytesLen * 2);
-			const val = processor.deserialize(valueBytes, def);
-			params[def.id] = transformer ? transformer(val, def) : val;
-		}
-		return params;
-	}
-	var processParam = (paramId, value, definitions, transformType) => {
-		const definition = definitions.find((d) => d.id === paramId);
-		const processor = ParameterProcessors[definition.type];
-		const transformer = processor[transformType];
-		return transformer?.(value, definition) || value;
-	};
-	var processParams = (values, definitions, transformType) => {
-		const paramValues = {};
-		for (const definition of definitions) {
-			const processor = ParameterProcessors[definition.type];
-			const value = values[definition.id];
-			const transformer = processor[transformType];
-			paramValues[definition.id] =
-				transformer?.(value, definition) || value;
-		}
-		return paramValues;
-	};
+  // ../fxhash-params/dist/chunk-FZWZHHQ2.js
+  function completeHexColor(hexCode) {
+    let hex = hexCode.replace("#", "");
+    if (hex.length === 6) {
+      hex = `${hex}ff`;
+    }
+    if (hex.length === 3) {
+      hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}ff`;
+    }
+    return hex;
+  }
+  var stringToHex = function(s) {
+    let rtn = "";
+    for (let i = 0; i < s.length; i++) {
+      rtn += s.charCodeAt(i).toString(16).padStart(4, "0");
+    }
+    return rtn;
+  };
+  var hexToString = function(h) {
+    const hx = h.match(/.{1,4}/g) || [];
+    let rtn = "";
+    for (let i = 0; i < hx.length; i++) {
+      const int = parseInt(hx[i], 16);
+      if (int === 0)
+        break;
+      rtn += String.fromCharCode(int);
+    }
+    return rtn;
+  };
+  var MIN_SAFE_INT64 = BigInt("-9223372036854775808");
+  var MAX_SAFE_INT64 = BigInt("9223372036854775807");
+  var ParameterProcessors = {
+    number: {
+      serialize: (input) => {
+        const view = new DataView(new ArrayBuffer(8));
+        view.setFloat64(0, input);
+        return view.getBigUint64(0).toString(16).padStart(16, "0");
+      },
+      deserialize: (input) => {
+        const view = new DataView(new ArrayBuffer(8));
+        for (let i = 0; i < 8; i++) {
+          view.setUint8(i, parseInt(input.substring(i * 2, i * 2 + 2), 16));
+        }
+        return view.getFloat64(0);
+      },
+      bytesLength: () => 8,
+      constrain: (value, definition) => {
+        let min = Number.MIN_SAFE_INTEGER;
+        if (typeof definition.options?.min !== "undefined")
+          min = Number(definition.options.min);
+        let max = Number.MAX_SAFE_INTEGER;
+        if (typeof definition.options?.max !== "undefined")
+          max = Number(definition.options.max);
+        max = Math.min(max, Number.MAX_SAFE_INTEGER);
+        min = Math.max(min, Number.MIN_SAFE_INTEGER);
+        const v = Math.min(Math.max(value, min), max);
+        if (definition?.options?.step) {
+          const t = 1 / definition?.options?.step;
+          return Math.round(v * t) / t;
+        }
+        return v;
+      },
+      random: (definition) => {
+        let min = Number.MIN_SAFE_INTEGER;
+        if (typeof definition.options?.min !== "undefined")
+          min = Number(definition.options.min);
+        let max = Number.MAX_SAFE_INTEGER;
+        if (typeof definition.options?.max !== "undefined")
+          max = Number(definition.options.max);
+        max = Math.min(max, Number.MAX_SAFE_INTEGER);
+        min = Math.max(min, Number.MIN_SAFE_INTEGER);
+        const v = Math.random() * (max - min) + min;
+        if (definition?.options?.step) {
+          const t = 1 / definition?.options?.step;
+          return Math.round(v * t) / t;
+        }
+        return v;
+      }
+    },
+    bigint: {
+      serialize: (input) => {
+        const view = new DataView(new ArrayBuffer(8));
+        view.setBigInt64(0, BigInt(input));
+        return view.getBigUint64(0).toString(16).padStart(16, "0");
+      },
+      deserialize: (input) => {
+        const view = new DataView(new ArrayBuffer(8));
+        for (let i = 0; i < 8; i++) {
+          view.setUint8(i, parseInt(input.substring(i * 2, i * 2 + 2), 16));
+        }
+        return view.getBigInt64(0);
+      },
+      bytesLength: () => 8,
+      random: (definition) => {
+        let min = MIN_SAFE_INT64;
+        let max = MAX_SAFE_INT64;
+        if (typeof definition.options?.min !== "undefined")
+          min = BigInt(definition.options.min);
+        if (typeof definition.options?.max !== "undefined")
+          max = BigInt(definition.options.max);
+        const range = max - min;
+        const bits = range.toString(2).length;
+        let random;
+        do {
+          random = BigInt(
+            "0b" + Array.from(
+              crypto.getRandomValues(new Uint8Array(Math.ceil(bits / 8)))
+            ).map((b) => b.toString(2).padStart(8, "0")).join("")
+          );
+        } while (random > range);
+        return random + min;
+      }
+    },
+    boolean: {
+      serialize: (input) => {
+        return typeof input === "boolean" ? input ? "01" : "00" : typeof input === "string" ? input === "true" ? "01" : "00" : "00";
+      },
+      deserialize: (input) => {
+        return input === "00" ? false : true;
+      },
+      bytesLength: () => 1,
+      random: () => Math.random() < 0.5
+    },
+    color: {
+      serialize: (input) => {
+        return completeHexColor(input);
+      },
+      deserialize: (input) => {
+        return input;
+      },
+      bytesLength: () => 4,
+      transform: (input) => {
+        const color = completeHexColor(input);
+        const r = parseInt(color.slice(0, 2), 16);
+        const g = parseInt(color.slice(2, 4), 16);
+        const b = parseInt(color.slice(4, 6), 16);
+        const a = parseInt(color.slice(6, 8), 16);
+        return {
+          hex: {
+            rgb: "#" + input.slice(0, 6),
+            rgba: "#" + input
+          },
+          obj: {
+            rgb: { r, g, b },
+            rgba: { r, g, b, a }
+          },
+          arr: {
+            rgb: [r, g, b],
+            rgba: [r, g, b, a]
+          }
+        };
+      },
+      constrain: (value) => {
+        const hex = value.replace("#", "");
+        return hex.slice(0, 8).padEnd(8, "f");
+      },
+      random: () => `${[...Array(8)].map(() => Math.floor(Math.random() * 16).toString(16)).join("")}`
+    },
+    string: {
+      serialize: (input, def) => {
+        if (!def.version) {
+          let hex2 = stringToHex(input.substring(0, 64));
+          hex2 = hex2.padEnd(64 * 4, "0");
+          return hex2;
+        }
+        let max = 64;
+        if (typeof def.options?.maxLength !== "undefined")
+          max = Number(def.options.maxLength);
+        let hex = stringToHex(input.substring(0, max));
+        hex = hex.padEnd(max * 4, "0");
+        return hex;
+      },
+      deserialize: (input) => {
+        return hexToString(input);
+      },
+      bytesLength: (def) => {
+        if (!def.version) {
+          return 64 * 2;
+        }
+        if (typeof def.options?.maxLength !== "undefined")
+          return Number(def.options.maxLength) * 2;
+        return 64 * 2;
+      },
+      random: (definition) => {
+        let min = 0;
+        if (typeof definition.options?.minLength !== "undefined")
+          min = definition.options.minLength;
+        let max = 64;
+        if (typeof definition.options?.maxLength !== "undefined")
+          max = definition.options.maxLength;
+        const length = Math.round(Math.random() * (max - min) + min);
+        return [...Array(length)].map((i) => (~~(Math.random() * 36)).toString(36)).join("");
+      },
+      constrain: (value, definition) => {
+        let min = 0;
+        if (typeof definition.options?.minLength !== "undefined")
+          min = definition.options.minLength;
+        let max = 64;
+        if (typeof definition.options?.maxLength !== "undefined")
+          max = definition.options.maxLength;
+        const v = value.slice(0, max);
+        if (v.length < min) {
+          return v.padEnd(min);
+        }
+        return v;
+      }
+    },
+    bytes: {
+      serialize: (input, def) => {
+        return Array.from(input).map((i) => i.toString(16).padStart(2, "0")).join("");
+      },
+      deserialize: (input, def) => {
+        const len = input.length / 2;
+        const uint8 = new Uint8Array(len);
+        let idx;
+        for (let i = 0; i < len; i++) {
+          idx = i * 2;
+          uint8[i] = parseInt(`${input[idx]}${input[idx + 1]}`, 16);
+        }
+        return uint8;
+      },
+      bytesLength: (def) => def.options.length,
+      random: (def) => {
+        const len = def.options?.length || 0;
+        const uint8 = new Uint8Array(len);
+        for (let i = 0; i < len; i++) {
+          uint8[i] = Math.random() * 255 | 0;
+        }
+        return uint8;
+      }
+    },
+    select: {
+      serialize: (input, def) => {
+        return Math.min(255, def.options?.options?.indexOf(input) || 0).toString(16).padStart(2, "0");
+      },
+      deserialize: (input, def) => {
+        const idx = parseInt(input, 16);
+        return def.options?.options?.[idx] || def.options?.options?.[0] || "";
+      },
+      bytesLength: () => 1,
+      // index between 0 and 255
+      constrain: (value, definition) => {
+        if (definition.options.options.includes(value)) {
+          return value;
+        }
+        return definition.options.options[0];
+      },
+      random: (definition) => {
+        const index = Math.round(
+          Math.random() * (definition.options.options.length - 1) + 0
+        );
+        return definition?.options?.options[index];
+      }
+    }
+  };
+  function serializeParams(params, definition) {
+    let bytes = "";
+    if (!definition)
+      return bytes;
+    for (const def of definition) {
+      const { id, type } = def;
+      const processor = ParameterProcessors[type];
+      const v = params[id];
+      const val = typeof v !== "undefined" ? v : typeof def.default !== "undefined" ? def.default : processor.random(def);
+      const serialized = processor.serialize(val, def);
+      bytes += serialized;
+    }
+    return bytes;
+  }
+  function deserializeParams(bytes, definition, options) {
+    const params = {};
+    for (const def of definition) {
+      const processor = ParameterProcessors[def.type];
+      const transformer = options.withTransform && processor[options.transformType || "transform"];
+      if (!bytes) {
+        let v;
+        if (typeof def.default === "undefined")
+          v = processor.random(def);
+        else
+          v = def.default;
+        params[def.id] = transformer ? transformer(v, def) : v;
+        continue;
+      }
+      const bytesLen = processor.bytesLength(def);
+      const valueBytes = bytes.substring(0, bytesLen * 2);
+      bytes = bytes.substring(bytesLen * 2);
+      const val = processor.deserialize(valueBytes, def);
+      params[def.id] = transformer ? transformer(val, def) : val;
+    }
+    return params;
+  }
+  var processParam = (paramId, value, definitions, transformType) => {
+    const definition = definitions.find((d) => d.id === paramId);
+    const processor = ParameterProcessors[definition.type];
+    const transformer = processor[transformType];
+    return transformer?.(value, definition) || value;
+  };
+  var processParams = (values, definitions, transformType) => {
+    const paramValues = {};
+    for (const definition of definitions) {
+      const processor = ParameterProcessors[definition.type];
+      const value = values[definition.id];
+      const transformer = processor[transformType];
+      paramValues[definition.id] = transformer?.(value, definition) || value;
+    }
+    return paramValues;
+  };
 
-	// src/sdk/index.ts
-	function createFxhashSdk(window2, options) {
-		const { parent } = window2;
-		const search = new URLSearchParams(window2.location.search);
-		const fxhash = search.get("fxhash") || "oo" + getRandomHash(49);
-		let fxrand = createFxRandom(fxhash, 2);
-		const fxminter = search.get("fxminter") || "tz1" + getRandomHash(33);
-		let fxrandminter = createFxRandom(fxminter, 3);
-		const isFxpreview = search.get("preview") === "1";
-		function fxpreview() {
-			window2.dispatchEvent(new Event("fxhash-preview"));
-			setTimeout(() => fxpreview(), 500);
-		}
-		const searchParams = window2.location.hash;
-		const initialInputBytes = searchParams?.replace("#0x", "");
-		const $fx = {
-			_version: "3.3.0",
-			_processors: ParameterProcessors,
-			// where params def & features will be stored
-			_params: void 0,
-			_features: void 0,
-			// where the parameter values are stored
-			_paramValues: {},
-			_listeners: {},
-			_receiveUpdateParams: async function (newRawValues, onDefault) {
-				const handlers = await this.propagateEvent(
-					"params:update",
-					newRawValues
-				);
-				handlers.forEach(([optInDefault, onDone]) => {
-					if (!(typeof optInDefault == "boolean" && !optInDefault)) {
-						this._updateParams(newRawValues);
-						onDefault?.();
-					}
-					onDone?.(optInDefault, newRawValues);
-				});
-				if (handlers.length === 0) {
-					this._updateParams(newRawValues);
-					onDefault?.();
-				}
-			},
-			_updateParams: function (newRawValues) {
-				const constrained = processParams(
-					{ ...this._rawValues, ...newRawValues },
-					this._params,
-					"constrain"
-				);
-				Object.keys(constrained).forEach((paramId) => {
-					this._rawValues[paramId] = constrained[paramId];
-				});
-				this._paramValues = processParams(
-					this._rawValues,
-					this._params,
-					"transform"
-				);
-				this._updateInputBytes();
-			},
-			_updateInputBytes: function () {
-				const bytes = serializeParams(this._rawValues, this._params);
-				this.inputBytes = bytes;
-			},
-			_emitParams: function (newRawValues) {
-				const constrainedValues = Object.keys(newRawValues).reduce(
-					(acc, paramId) => {
-						acc[paramId] = processParam(
-							paramId,
-							newRawValues[paramId],
-							this._params,
-							"constrain"
-						);
-						return acc;
-					},
-					{}
-				);
-				this._receiveUpdateParams(constrainedValues, () => {
-					parent.postMessage(
-						{
-							id: "fxhash_emit:params:update",
-							data: {
-								params: constrainedValues,
-							},
-						},
-						"*"
-					);
-				});
-			},
-			hash: fxhash,
-			rand: fxrand,
-			minter: fxminter,
-			randminter: fxrandminter,
-			iteration: Number(search.get("fxiteration")) || 1,
-			context: search.get("fxcontext") || "standalone",
-			preview: fxpreview,
-			isPreview: isFxpreview,
-			params: function (definition) {
-				this._params = definition.map((def) => ({
-					...def,
-					version: this._version,
-				}));
-				this._rawValues = deserializeParams(
-					initialInputBytes,
-					this._params,
-					{
-						withTransform: true,
-						transformType: "constrain",
-					}
-				);
-				this._paramValues = processParams(
-					this._rawValues,
-					this._params,
-					"transform"
-				);
-				this._updateInputBytes();
-			},
-			features: function (features) {
-				this._features = features;
-			},
-			getFeature: function (id) {
-				return this._features[id];
-			},
-			getFeatures: function () {
-				return this._features;
-			},
-			getParam: function (id) {
-				return this._paramValues[id];
-			},
-			getParams: function () {
-				return this._paramValues;
-			},
-			getRawParam: function (id) {
-				return this._rawValues[id];
-			},
-			getRawParams: function () {
-				return this._rawValues;
-			},
-			getRandomParam: function (id) {
-				const definition = this._params.find((d) => d.id === id);
-				const processor = ParameterProcessors[definition.type];
-				return processor.random(definition);
-			},
-			getDefinitions: function () {
-				return this._params;
-			},
-			stringifyParams: function (params) {
-				return JSON.stringify(
-					params || this._rawValues,
-					(key, value) => {
-						if (typeof value === "bigint") return value.toString();
-						return value;
-					},
-					2
-				);
-			},
-			on: function (name, callback, onDone) {
-				if (!this._listeners[name]) {
-					this._listeners[name] = [];
-				}
-				this._listeners[name].push([callback, onDone]);
-				return () => {
-					const index = this._listeners[name].findIndex(
-						([c]) => c === callback
-					);
-					if (index > -1) {
-						this._listeners[name].splice(index, 1);
-					}
-				};
-			},
-			propagateEvent: async function (name, data) {
-				const results = [];
-				if (this._listeners?.[name]) {
-					for (const [callback, onDone] of this._listeners[name]) {
-						const result = callback(data);
-						results.push([
-							result instanceof Promise ? await result : result,
-							onDone,
-						]);
-					}
-				}
-				return results;
-			},
-			emit: function (id, data) {
-				switch (id) {
-					case "params:update":
-						this._emitParams(data);
-						break;
-					default:
-						console.log("$fx.emit called with unknown id:", id);
-						break;
-				}
-			},
-		};
-		const resetFxRand = () => {
-			fxrand = createFxRandom(fxhash, 2);
-			$fx.rand = fxrand;
-			fxrand.reset = resetFxRand;
-		};
-		fxrand.reset = resetFxRand;
-		const resetFxRandMinter = () => {
-			fxrandminter = createFxRandom(fxminter, 3);
-			$fx.randminter = fxrandminter;
-			fxrandminter.reset = resetFxRandMinter;
-		};
-		fxrandminter.reset = resetFxRandMinter;
-		window2.addEventListener("message", (event) => {
-			if (event.data === "fxhash_getInfo") {
-				parent.postMessage(
-					{
-						id: "fxhash_getInfo",
-						data: {
-							version: window2.$fx._version,
-							hash: window2.$fx.hash,
-							iteration: window2.$fx.iteration,
-							features: window2.$fx.getFeatures(),
-							params: {
-								definitions: window2.$fx.getDefinitions(),
-								values: window2.$fx.getRawParams(),
-							},
-							minter: window2.$fx.minter,
-						},
-					},
-					"*"
-				);
-			}
-			if (event.data?.id === "fxhash_params:update") {
-				const { params } = event.data.data;
-				if (params) window2.$fx._receiveUpdateParams(params);
-			}
-		});
-		return $fx;
-	}
+  // src/sdk/index.ts
+  function createFxhashSdk(window2, options) {
+    const { parent } = window2;
+    const search = new URLSearchParams(window2.location.search);
+    const fxhash = search.get("fxhash") || "oo" + getRandomHash(49);
+    let fxrand = createFxRandom(fxhash, 2);
+    const fxminter = search.get("fxminter") || "tz1" + getRandomHash(33);
+    let fxrandminter = createFxRandom(fxminter, 3);
+    const isFxpreview = search.get("preview") === "1";
+    function fxpreview() {
+      window2.dispatchEvent(new Event("fxhash-preview"));
+      setTimeout(() => fxpreview(), 500);
+    }
+    const searchParams = window2.location.hash;
+    const initialInputBytes = searchParams?.replace("#0x", "");
+    const $fx = {
+      _version: "3.3.0",
+      _processors: ParameterProcessors,
+      // where params def & features will be stored
+      _params: void 0,
+      _features: void 0,
+      // where the parameter values are stored
+      _paramValues: {},
+      _listeners: {},
+      _receiveUpdateParams: async function(newRawValues, onDefault) {
+        const handlers = await this.propagateEvent("params:update", newRawValues);
+        handlers.forEach(([optInDefault, onDone]) => {
+          if (!(typeof optInDefault == "boolean" && !optInDefault)) {
+            this._updateParams(newRawValues);
+            onDefault?.();
+          }
+          onDone?.(optInDefault, newRawValues);
+        });
+        if (handlers.length === 0) {
+          this._updateParams(newRawValues);
+          onDefault?.();
+        }
+      },
+      _updateParams: function(newRawValues) {
+        const constrained = processParams(
+          { ...this._rawValues, ...newRawValues },
+          this._params,
+          "constrain"
+        );
+        Object.keys(constrained).forEach((paramId) => {
+          this._rawValues[paramId] = constrained[paramId];
+        });
+        this._paramValues = processParams(
+          this._rawValues,
+          this._params,
+          "transform"
+        );
+        this._updateInputBytes();
+      },
+      _updateInputBytes: function() {
+        const bytes = serializeParams(this._rawValues, this._params);
+        this.inputBytes = bytes;
+      },
+      _emitParams: function(newRawValues) {
+        const constrainedValues = Object.keys(newRawValues).reduce(
+          (acc, paramId) => {
+            acc[paramId] = processParam(
+              paramId,
+              newRawValues[paramId],
+              this._params,
+              "constrain"
+            );
+            return acc;
+          },
+          {}
+        );
+        this._receiveUpdateParams(constrainedValues, () => {
+          parent.postMessage(
+            {
+              id: "fxhash_emit:params:update",
+              data: {
+                params: constrainedValues
+              }
+            },
+            "*"
+          );
+        });
+      },
+      hash: fxhash,
+      rand: fxrand,
+      minter: fxminter,
+      randminter: fxrandminter,
+      iteration: Number(search.get("fxiteration")) || 1,
+      context: search.get("fxcontext") || "standalone",
+      preview: fxpreview,
+      isPreview: isFxpreview,
+      params: function(definition) {
+        this._params = definition.map((def) => ({ ...def, version: this._version }));
+        this._rawValues = deserializeParams(initialInputBytes, this._params, {
+          withTransform: true,
+          transformType: "constrain"
+        });
+        this._paramValues = processParams(
+          this._rawValues,
+          this._params,
+          "transform"
+        );
+        this._updateInputBytes();
+      },
+      features: function(features) {
+        this._features = features;
+      },
+      getFeature: function(id) {
+        return this._features[id];
+      },
+      getFeatures: function() {
+        return this._features;
+      },
+      getParam: function(id) {
+        return this._paramValues[id];
+      },
+      getParams: function() {
+        return this._paramValues;
+      },
+      getRawParam: function(id) {
+        return this._rawValues[id];
+      },
+      getRawParams: function() {
+        return this._rawValues;
+      },
+      getRandomParam: function(id) {
+        const definition = this._params.find((d) => d.id === id);
+        const processor = ParameterProcessors[definition.type];
+        return processor.random(definition);
+      },
+      getDefinitions: function() {
+        return this._params;
+      },
+      stringifyParams: function(params) {
+        return JSON.stringify(
+          params || this._rawValues,
+          (key, value) => {
+            if (typeof value === "bigint")
+              return value.toString();
+            return value;
+          },
+          2
+        );
+      },
+      on: function(name, callback, onDone) {
+        if (!this._listeners[name]) {
+          this._listeners[name] = [];
+        }
+        this._listeners[name].push([callback, onDone]);
+        return () => {
+          const index = this._listeners[name].findIndex(([c]) => c === callback);
+          if (index > -1) {
+            this._listeners[name].splice(index, 1);
+          }
+        };
+      },
+      propagateEvent: async function(name, data) {
+        const results = [];
+        if (this._listeners?.[name]) {
+          for (const [callback, onDone] of this._listeners[name]) {
+            const result = callback(data);
+            results.push([
+              result instanceof Promise ? await result : result,
+              onDone
+            ]);
+          }
+        }
+        return results;
+      },
+      emit: function(id, data) {
+        switch (id) {
+          case "params:update":
+            this._emitParams(data);
+            break;
+          default:
+            console.log("$fx.emit called with unknown id:", id);
+            break;
+        }
+      }
+    };
+    const resetFxRand = () => {
+      fxrand = createFxRandom(fxhash, 2);
+      $fx.rand = fxrand;
+      fxrand.reset = resetFxRand;
+    };
+    fxrand.reset = resetFxRand;
+    const resetFxRandMinter = () => {
+      fxrandminter = createFxRandom(fxminter, 3);
+      $fx.randminter = fxrandminter;
+      fxrandminter.reset = resetFxRandMinter;
+    };
+    fxrandminter.reset = resetFxRandMinter;
+    window2.addEventListener("message", (event) => {
+      if (event.data === "fxhash_getInfo") {
+        parent.postMessage(
+          {
+            id: "fxhash_getInfo",
+            data: {
+              version: window2.$fx._version,
+              hash: window2.$fx.hash,
+              iteration: window2.$fx.iteration,
+              features: window2.$fx.getFeatures(),
+              params: {
+                definitions: window2.$fx.getDefinitions(),
+                values: window2.$fx.getRawParams()
+              },
+              minter: window2.$fx.minter
+            }
+          },
+          "*"
+        );
+      }
+      if (event.data?.id === "fxhash_params:update") {
+        const { params } = event.data.data;
+        if (params)
+          window2.$fx._receiveUpdateParams(params);
+      }
+    });
+    return $fx;
+  }
 
-	// src/index.ts
-	window.$fx = createFxhashSdk(window, {});
+  // src/index.ts
+  window.$fx = createFxhashSdk(window, {});
 })();
 //# sourceMappingURL=fxhash.js.map

--- a/public/fxhash.js
+++ b/public/fxhash.js
@@ -1,0 +1,628 @@
+"use strict";
+(() => {
+	// src/sdk/math.ts
+	var alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
+	function b58dec(str) {
+		return [...str].reduce(function (p, c) {
+			return (p * alphabet.length + alphabet.indexOf(c)) | 0;
+		}, 0);
+	}
+	function sfc32(seed) {
+		let a = seed[0] | 0;
+		let b = seed[1] | 0;
+		let c = seed[2] | 0;
+		let d = seed[3] | 0;
+		return function () {
+			a |= 0;
+			b |= 0;
+			c |= 0;
+			d |= 0;
+			const t = (((a + b) | 0) + d) | 0;
+			d = (d + 1) | 0;
+			a = b ^ (b >>> 9);
+			b = (c + (c << 3)) | 0;
+			c = (c << 21) | (c >>> 11);
+			c = (c + t) | 0;
+			return (t >>> 0) / 4294967296;
+		};
+	}
+	function matcher(str, start) {
+		return str
+			.slice(start)
+			.match(new RegExp(".{" + ((str.length - start) >> 2) + "}", "g"))
+			.map(function (substring) {
+				return b58dec(substring);
+			});
+	}
+	function getRandomHash(n) {
+		return Array(n)
+			.fill(0)
+			.map(function (_) {
+				return alphabet[(Math.random() * alphabet.length) | 0];
+			})
+			.join("");
+	}
+	function createFxRandom(fxhash, start) {
+		return sfc32(matcher(fxhash, start));
+	}
+
+	// ../fxhash-params/dist/chunk-FZWZHHQ2.js
+	function completeHexColor(hexCode) {
+		let hex = hexCode.replace("#", "");
+		if (hex.length === 6) {
+			hex = `${hex}ff`;
+		}
+		if (hex.length === 3) {
+			hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}ff`;
+		}
+		return hex;
+	}
+	var stringToHex = function (s) {
+		let rtn = "";
+		for (let i = 0; i < s.length; i++) {
+			rtn += s.charCodeAt(i).toString(16).padStart(4, "0");
+		}
+		return rtn;
+	};
+	var hexToString = function (h) {
+		const hx = h.match(/.{1,4}/g) || [];
+		let rtn = "";
+		for (let i = 0; i < hx.length; i++) {
+			const int = parseInt(hx[i], 16);
+			if (int === 0) break;
+			rtn += String.fromCharCode(int);
+		}
+		return rtn;
+	};
+	var MIN_SAFE_INT64 = BigInt("-9223372036854775808");
+	var MAX_SAFE_INT64 = BigInt("9223372036854775807");
+	var ParameterProcessors = {
+		number: {
+			serialize: (input) => {
+				const view = new DataView(new ArrayBuffer(8));
+				view.setFloat64(0, input);
+				return view.getBigUint64(0).toString(16).padStart(16, "0");
+			},
+			deserialize: (input) => {
+				const view = new DataView(new ArrayBuffer(8));
+				for (let i = 0; i < 8; i++) {
+					view.setUint8(
+						i,
+						parseInt(input.substring(i * 2, i * 2 + 2), 16)
+					);
+				}
+				return view.getFloat64(0);
+			},
+			bytesLength: () => 8,
+			constrain: (value, definition) => {
+				let min = Number.MIN_SAFE_INTEGER;
+				if (typeof definition.options?.min !== "undefined")
+					min = Number(definition.options.min);
+				let max = Number.MAX_SAFE_INTEGER;
+				if (typeof definition.options?.max !== "undefined")
+					max = Number(definition.options.max);
+				max = Math.min(max, Number.MAX_SAFE_INTEGER);
+				min = Math.max(min, Number.MIN_SAFE_INTEGER);
+				const v = Math.min(Math.max(value, min), max);
+				if (definition?.options?.step) {
+					const t = 1 / definition?.options?.step;
+					return Math.round(v * t) / t;
+				}
+				return v;
+			},
+			random: (definition) => {
+				let min = Number.MIN_SAFE_INTEGER;
+				if (typeof definition.options?.min !== "undefined")
+					min = Number(definition.options.min);
+				let max = Number.MAX_SAFE_INTEGER;
+				if (typeof definition.options?.max !== "undefined")
+					max = Number(definition.options.max);
+				max = Math.min(max, Number.MAX_SAFE_INTEGER);
+				min = Math.max(min, Number.MIN_SAFE_INTEGER);
+				const v = Math.random() * (max - min) + min;
+				if (definition?.options?.step) {
+					const t = 1 / definition?.options?.step;
+					return Math.round(v * t) / t;
+				}
+				return v;
+			},
+		},
+		bigint: {
+			serialize: (input) => {
+				const view = new DataView(new ArrayBuffer(8));
+				view.setBigInt64(0, BigInt(input));
+				return view.getBigUint64(0).toString(16).padStart(16, "0");
+			},
+			deserialize: (input) => {
+				const view = new DataView(new ArrayBuffer(8));
+				for (let i = 0; i < 8; i++) {
+					view.setUint8(
+						i,
+						parseInt(input.substring(i * 2, i * 2 + 2), 16)
+					);
+				}
+				return view.getBigInt64(0);
+			},
+			bytesLength: () => 8,
+			random: (definition) => {
+				let min = MIN_SAFE_INT64;
+				let max = MAX_SAFE_INT64;
+				if (typeof definition.options?.min !== "undefined")
+					min = BigInt(definition.options.min);
+				if (typeof definition.options?.max !== "undefined")
+					max = BigInt(definition.options.max);
+				const range = max - min;
+				const bits = range.toString(2).length;
+				let random;
+				do {
+					random = BigInt(
+						"0b" +
+							Array.from(
+								crypto.getRandomValues(
+									new Uint8Array(Math.ceil(bits / 8))
+								)
+							)
+								.map((b) => b.toString(2).padStart(8, "0"))
+								.join("")
+					);
+				} while (random > range);
+				return random + min;
+			},
+		},
+		boolean: {
+			serialize: (input) => {
+				return typeof input === "boolean"
+					? input
+						? "01"
+						: "00"
+					: typeof input === "string"
+					? input === "true"
+						? "01"
+						: "00"
+					: "00";
+			},
+			deserialize: (input) => {
+				return input === "00" ? false : true;
+			},
+			bytesLength: () => 1,
+			random: () => Math.random() < 0.5,
+		},
+		color: {
+			serialize: (input) => {
+				return completeHexColor(input);
+			},
+			deserialize: (input) => {
+				return input;
+			},
+			bytesLength: () => 4,
+			transform: (input) => {
+				const color = completeHexColor(input);
+				const r = parseInt(color.slice(0, 2), 16);
+				const g = parseInt(color.slice(2, 4), 16);
+				const b = parseInt(color.slice(4, 6), 16);
+				const a = parseInt(color.slice(6, 8), 16);
+				return {
+					hex: {
+						rgb: "#" + input.slice(0, 6),
+						rgba: "#" + input,
+					},
+					obj: {
+						rgb: { r, g, b },
+						rgba: { r, g, b, a },
+					},
+					arr: {
+						rgb: [r, g, b],
+						rgba: [r, g, b, a],
+					},
+				};
+			},
+			constrain: (value) => {
+				const hex = value.replace("#", "");
+				return hex.slice(0, 8).padEnd(8, "f");
+			},
+			random: () =>
+				`${[...Array(8)]
+					.map(() => Math.floor(Math.random() * 16).toString(16))
+					.join("")}`,
+		},
+		string: {
+			serialize: (input, def) => {
+				if (!def.version) {
+					let hex2 = stringToHex(input.substring(0, 64));
+					hex2 = hex2.padEnd(64 * 4, "0");
+					return hex2;
+				}
+				let max = 64;
+				if (typeof def.options?.maxLength !== "undefined")
+					max = Number(def.options.maxLength);
+				let hex = stringToHex(input.substring(0, max));
+				hex = hex.padEnd(max * 4, "0");
+				return hex;
+			},
+			deserialize: (input) => {
+				return hexToString(input);
+			},
+			bytesLength: (def) => {
+				if (!def.version) {
+					return 64 * 2;
+				}
+				if (typeof def.options?.maxLength !== "undefined")
+					return Number(def.options.maxLength) * 2;
+				return 64 * 2;
+			},
+			random: (definition) => {
+				let min = 0;
+				if (typeof definition.options?.minLength !== "undefined")
+					min = definition.options.minLength;
+				let max = 64;
+				if (typeof definition.options?.maxLength !== "undefined")
+					max = definition.options.maxLength;
+				const length = Math.round(Math.random() * (max - min) + min);
+				return [...Array(length)]
+					.map((i) => (~~(Math.random() * 36)).toString(36))
+					.join("");
+			},
+			constrain: (value, definition) => {
+				let min = 0;
+				if (typeof definition.options?.minLength !== "undefined")
+					min = definition.options.minLength;
+				let max = 64;
+				if (typeof definition.options?.maxLength !== "undefined")
+					max = definition.options.maxLength;
+				const v = value.slice(0, max);
+				if (v.length < min) {
+					return v.padEnd(min);
+				}
+				return v;
+			},
+		},
+		bytes: {
+			serialize: (input, def) => {
+				return Array.from(input)
+					.map((i) => i.toString(16).padStart(2, "0"))
+					.join("");
+			},
+			deserialize: (input, def) => {
+				const len = input.length / 2;
+				const uint8 = new Uint8Array(len);
+				let idx;
+				for (let i = 0; i < len; i++) {
+					idx = i * 2;
+					uint8[i] = parseInt(`${input[idx]}${input[idx + 1]}`, 16);
+				}
+				return uint8;
+			},
+			bytesLength: (def) => def.options.length,
+			random: (def) => {
+				const len = def.options?.length || 0;
+				const uint8 = new Uint8Array(len);
+				for (let i = 0; i < len; i++) {
+					uint8[i] = (Math.random() * 255) | 0;
+				}
+				return uint8;
+			},
+		},
+		select: {
+			serialize: (input, def) => {
+				return Math.min(255, def.options?.options?.indexOf(input) || 0)
+					.toString(16)
+					.padStart(2, "0");
+			},
+			deserialize: (input, def) => {
+				const idx = parseInt(input, 16);
+				return (
+					def.options?.options?.[idx] ||
+					def.options?.options?.[0] ||
+					""
+				);
+			},
+			bytesLength: () => 1,
+			// index between 0 and 255
+			constrain: (value, definition) => {
+				if (definition.options.options.includes(value)) {
+					return value;
+				}
+				return definition.options.options[0];
+			},
+			random: (definition) => {
+				const index = Math.round(
+					Math.random() * (definition.options.options.length - 1) + 0
+				);
+				return definition?.options?.options[index];
+			},
+		},
+	};
+	function serializeParams(params, definition) {
+		let bytes = "";
+		if (!definition) return bytes;
+		for (const def of definition) {
+			const { id, type } = def;
+			const processor = ParameterProcessors[type];
+			const v = params[id];
+			const val =
+				typeof v !== "undefined"
+					? v
+					: typeof def.default !== "undefined"
+					? def.default
+					: processor.random(def);
+			const serialized = processor.serialize(val, def);
+			bytes += serialized;
+		}
+		return bytes;
+	}
+	function deserializeParams(bytes, definition, options) {
+		const params = {};
+		for (const def of definition) {
+			const processor = ParameterProcessors[def.type];
+			const transformer =
+				options.withTransform &&
+				processor[options.transformType || "transform"];
+			if (!bytes) {
+				let v;
+				if (typeof def.default === "undefined")
+					v = processor.random(def);
+				else v = def.default;
+				params[def.id] = transformer ? transformer(v, def) : v;
+				continue;
+			}
+			const bytesLen = processor.bytesLength(def);
+			const valueBytes = bytes.substring(0, bytesLen * 2);
+			bytes = bytes.substring(bytesLen * 2);
+			const val = processor.deserialize(valueBytes, def);
+			params[def.id] = transformer ? transformer(val, def) : val;
+		}
+		return params;
+	}
+	var processParam = (paramId, value, definitions, transformType) => {
+		const definition = definitions.find((d) => d.id === paramId);
+		const processor = ParameterProcessors[definition.type];
+		const transformer = processor[transformType];
+		return transformer?.(value, definition) || value;
+	};
+	var processParams = (values, definitions, transformType) => {
+		const paramValues = {};
+		for (const definition of definitions) {
+			const processor = ParameterProcessors[definition.type];
+			const value = values[definition.id];
+			const transformer = processor[transformType];
+			paramValues[definition.id] =
+				transformer?.(value, definition) || value;
+		}
+		return paramValues;
+	};
+
+	// src/sdk/index.ts
+	function createFxhashSdk(window2, options) {
+		const { parent } = window2;
+		const search = new URLSearchParams(window2.location.search);
+		const fxhash = search.get("fxhash") || "oo" + getRandomHash(49);
+		let fxrand = createFxRandom(fxhash, 2);
+		const fxminter = search.get("fxminter") || "tz1" + getRandomHash(33);
+		let fxrandminter = createFxRandom(fxminter, 3);
+		const isFxpreview = search.get("preview") === "1";
+		function fxpreview() {
+			window2.dispatchEvent(new Event("fxhash-preview"));
+			setTimeout(() => fxpreview(), 500);
+		}
+		const searchParams = window2.location.hash;
+		const initialInputBytes = searchParams?.replace("#0x", "");
+		const $fx = {
+			_version: "3.3.0",
+			_processors: ParameterProcessors,
+			// where params def & features will be stored
+			_params: void 0,
+			_features: void 0,
+			// where the parameter values are stored
+			_paramValues: {},
+			_listeners: {},
+			_receiveUpdateParams: async function (newRawValues, onDefault) {
+				const handlers = await this.propagateEvent(
+					"params:update",
+					newRawValues
+				);
+				handlers.forEach(([optInDefault, onDone]) => {
+					if (!(typeof optInDefault == "boolean" && !optInDefault)) {
+						this._updateParams(newRawValues);
+						onDefault?.();
+					}
+					onDone?.(optInDefault, newRawValues);
+				});
+				if (handlers.length === 0) {
+					this._updateParams(newRawValues);
+					onDefault?.();
+				}
+			},
+			_updateParams: function (newRawValues) {
+				const constrained = processParams(
+					{ ...this._rawValues, ...newRawValues },
+					this._params,
+					"constrain"
+				);
+				Object.keys(constrained).forEach((paramId) => {
+					this._rawValues[paramId] = constrained[paramId];
+				});
+				this._paramValues = processParams(
+					this._rawValues,
+					this._params,
+					"transform"
+				);
+				this._updateInputBytes();
+			},
+			_updateInputBytes: function () {
+				const bytes = serializeParams(this._rawValues, this._params);
+				this.inputBytes = bytes;
+			},
+			_emitParams: function (newRawValues) {
+				const constrainedValues = Object.keys(newRawValues).reduce(
+					(acc, paramId) => {
+						acc[paramId] = processParam(
+							paramId,
+							newRawValues[paramId],
+							this._params,
+							"constrain"
+						);
+						return acc;
+					},
+					{}
+				);
+				this._receiveUpdateParams(constrainedValues, () => {
+					parent.postMessage(
+						{
+							id: "fxhash_emit:params:update",
+							data: {
+								params: constrainedValues,
+							},
+						},
+						"*"
+					);
+				});
+			},
+			hash: fxhash,
+			rand: fxrand,
+			minter: fxminter,
+			randminter: fxrandminter,
+			iteration: Number(search.get("fxiteration")) || 1,
+			context: search.get("fxcontext") || "standalone",
+			preview: fxpreview,
+			isPreview: isFxpreview,
+			params: function (definition) {
+				this._params = definition.map((def) => ({
+					...def,
+					version: this._version,
+				}));
+				this._rawValues = deserializeParams(
+					initialInputBytes,
+					this._params,
+					{
+						withTransform: true,
+						transformType: "constrain",
+					}
+				);
+				this._paramValues = processParams(
+					this._rawValues,
+					this._params,
+					"transform"
+				);
+				this._updateInputBytes();
+			},
+			features: function (features) {
+				this._features = features;
+			},
+			getFeature: function (id) {
+				return this._features[id];
+			},
+			getFeatures: function () {
+				return this._features;
+			},
+			getParam: function (id) {
+				return this._paramValues[id];
+			},
+			getParams: function () {
+				return this._paramValues;
+			},
+			getRawParam: function (id) {
+				return this._rawValues[id];
+			},
+			getRawParams: function () {
+				return this._rawValues;
+			},
+			getRandomParam: function (id) {
+				const definition = this._params.find((d) => d.id === id);
+				const processor = ParameterProcessors[definition.type];
+				return processor.random(definition);
+			},
+			getDefinitions: function () {
+				return this._params;
+			},
+			stringifyParams: function (params) {
+				return JSON.stringify(
+					params || this._rawValues,
+					(key, value) => {
+						if (typeof value === "bigint") return value.toString();
+						return value;
+					},
+					2
+				);
+			},
+			on: function (name, callback, onDone) {
+				if (!this._listeners[name]) {
+					this._listeners[name] = [];
+				}
+				this._listeners[name].push([callback, onDone]);
+				return () => {
+					const index = this._listeners[name].findIndex(
+						([c]) => c === callback
+					);
+					if (index > -1) {
+						this._listeners[name].splice(index, 1);
+					}
+				};
+			},
+			propagateEvent: async function (name, data) {
+				const results = [];
+				if (this._listeners?.[name]) {
+					for (const [callback, onDone] of this._listeners[name]) {
+						const result = callback(data);
+						results.push([
+							result instanceof Promise ? await result : result,
+							onDone,
+						]);
+					}
+				}
+				return results;
+			},
+			emit: function (id, data) {
+				switch (id) {
+					case "params:update":
+						this._emitParams(data);
+						break;
+					default:
+						console.log("$fx.emit called with unknown id:", id);
+						break;
+				}
+			},
+		};
+		const resetFxRand = () => {
+			fxrand = createFxRandom(fxhash, 2);
+			$fx.rand = fxrand;
+			fxrand.reset = resetFxRand;
+		};
+		fxrand.reset = resetFxRand;
+		const resetFxRandMinter = () => {
+			fxrandminter = createFxRandom(fxminter, 3);
+			$fx.randminter = fxrandminter;
+			fxrandminter.reset = resetFxRandMinter;
+		};
+		fxrandminter.reset = resetFxRandMinter;
+		window2.addEventListener("message", (event) => {
+			if (event.data === "fxhash_getInfo") {
+				parent.postMessage(
+					{
+						id: "fxhash_getInfo",
+						data: {
+							version: window2.$fx._version,
+							hash: window2.$fx.hash,
+							iteration: window2.$fx.iteration,
+							features: window2.$fx.getFeatures(),
+							params: {
+								definitions: window2.$fx.getDefinitions(),
+								values: window2.$fx.getRawParams(),
+							},
+							minter: window2.$fx.minter,
+						},
+					},
+					"*"
+				);
+			}
+			if (event.data?.id === "fxhash_params:update") {
+				const { params } = event.data.data;
+				if (params) window2.$fx._receiveUpdateParams(params);
+			}
+		});
+		return $fx;
+	}
+
+	// src/index.ts
+	window.$fx = createFxhashSdk(window, {});
+})();
+//# sourceMappingURL=fxhash.js.map

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,204 +2,99 @@
 # yarn lockfile v1
 
 
-"@esbuild/android-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
-  integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
-
-"@esbuild/android-arm@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
-  integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
-
-"@esbuild/android-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
-  integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
-
-"@esbuild/darwin-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
-  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
-
-"@esbuild/darwin-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
-  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
-
-"@esbuild/freebsd-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
-  integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
-
-"@esbuild/freebsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
-  integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
-
-"@esbuild/linux-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
-  integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
-
-"@esbuild/linux-arm@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
-  integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
-
-"@esbuild/linux-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
-  integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
-
-"@esbuild/linux-loong64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
-  integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
-
-"@esbuild/linux-mips64el@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
-  integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
-
-"@esbuild/linux-ppc64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
-  integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
-
-"@esbuild/linux-riscv64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
-  integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
-
-"@esbuild/linux-s390x@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
-  integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
-
-"@esbuild/linux-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
-  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
-
-"@esbuild/netbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
-  integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
-
-"@esbuild/openbsd-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
-  integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
-
-"@esbuild/sunos-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
-  integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
-
-"@esbuild/win32-arm64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
-  integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
-
-"@esbuild/win32-ia32@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
-  integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
-
 "@esbuild/win32-x64@0.18.20":
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
-  integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+  "integrity" "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="
+  "resolved" "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz"
+  "version" "0.18.20"
 
 "@jridgewell/gen-mapping@^0.3.0":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
-  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
+  "integrity" "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz"
+  "version" "0.3.3"
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+  "integrity" "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz"
+  "version" "3.1.0"
 
 "@jridgewell/set-array@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
-  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+  "integrity" "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz"
+  "version" "1.1.2"
 
 "@jridgewell/source-map@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.3.tgz#8108265659d4c33e72ffe14e33d6cc5eb59f2fda"
-  integrity sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==
+  "integrity" "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz"
+  "version" "0.3.3"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
 "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+  "integrity" "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
+  "version" "1.4.15"
+
+"@jridgewell/sourcemap-codec@1.4.14":
+  "integrity" "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz"
+  "version" "1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
-  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+  "integrity" "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA=="
+  "resolved" "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz"
+  "version" "0.3.18"
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@nodelib/fs.scandir@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
-  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  "integrity" "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="
+  "resolved" "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
+  "version" "2.1.5"
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
-    run-parallel "^1.1.9"
+    "run-parallel" "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
-  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+  "integrity" "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+  "resolved" "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
+  "version" "2.0.5"
 
 "@nodelib/fs.walk@^1.2.3":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
-  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  "integrity" "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="
+  "resolved" "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
+  "version" "1.2.8"
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
-    fastq "^1.6.0"
+    "fastq" "^1.6.0"
 
 "@rollup/pluginutils@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  "integrity" "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ=="
+  "resolved" "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz"
+  "version" "4.2.1"
   dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
+    "estree-walker" "^2.0.1"
+    "picomatch" "^2.2.2"
 
 "@thi.ng/adapt-dpi@^2.2.22":
-  version "2.2.22"
-  resolved "https://registry.yarnpkg.com/@thi.ng/adapt-dpi/-/adapt-dpi-2.2.22.tgz#f46b225edcdfa412d1ce9dc511a72827ca59c07d"
-  integrity sha512-jBF1KKTqyntUWbglQxM99az+hVH5vdi9v/W3D9lptK3k3CXjL6GOpAKlBOqRLFzg2l6LtP2B7t6cxNkT0mbtJQ==
+  "integrity" "sha512-jBF1KKTqyntUWbglQxM99az+hVH5vdi9v/W3D9lptK3k3CXjL6GOpAKlBOqRLFzg2l6LtP2B7t6cxNkT0mbtJQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/adapt-dpi/-/adapt-dpi-2.2.22.tgz"
+  "version" "2.2.22"
 
 "@thi.ng/api@^8.9.6":
-  version "8.9.6"
-  resolved "https://registry.yarnpkg.com/@thi.ng/api/-/api-8.9.6.tgz#8fc307eb659dafb5a52373e95795e1b9e3a74c51"
-  integrity sha512-9m+FS3klc3/3ehEy9FuLJdPI81rBWNxkAa24xiclNU7pShHyrSOdbiwFeKiVAFcLYW+fLhRomFEnTm80nncNuw==
+  "integrity" "sha512-9m+FS3klc3/3ehEy9FuLJdPI81rBWNxkAa24xiclNU7pShHyrSOdbiwFeKiVAFcLYW+fLhRomFEnTm80nncNuw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/api/-/api-8.9.6.tgz"
+  "version" "8.9.6"
 
 "@thi.ng/arrays@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@thi.ng/arrays/-/arrays-2.7.1.tgz#e00bd2b42d31e08a67cf663b21deb01ce82a140f"
-  integrity sha512-8tn7HrffAri6DgidBfb1y4+NA3McVtdCwPxE3ZdpIT4Tl32jxvFGqqkTvb9s44nTBHIb/+Qqmv1Zp1zyjJ/1+w==
+  "integrity" "sha512-8tn7HrffAri6DgidBfb1y4+NA3McVtdCwPxE3ZdpIT4Tl32jxvFGqqkTvb9s44nTBHIb/+Qqmv1Zp1zyjJ/1+w=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/arrays/-/arrays-2.7.1.tgz"
+  "version" "2.7.1"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -209,9 +104,9 @@
     "@thi.ng/random" "^3.6.11"
 
 "@thi.ng/associative@^6.3.16":
-  version "6.3.16"
-  resolved "https://registry.yarnpkg.com/@thi.ng/associative/-/associative-6.3.16.tgz#160b01d2ebbd7bca5d7b2a328e7317b743b48ef9"
-  integrity sha512-CRMldXcSGz/ZlV4aslYjnehpmi7AFmyN+asad8CdOBP+XTuBbH5e3+GP8xc+/cKFJGnmIcQ+5k1ZMcSzupMTlg==
+  "integrity" "sha512-CRMldXcSGz/ZlV4aslYjnehpmi7AFmyN+asad8CdOBP+XTuBbH5e3+GP8xc+/cKFJGnmIcQ+5k1ZMcSzupMTlg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/associative/-/associative-6.3.16.tgz"
+  "version" "6.3.16"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/arrays" "^2.7.1"
@@ -223,31 +118,31 @@
     "@thi.ng/errors" "^2.4.0"
     "@thi.ng/random" "^3.6.11"
     "@thi.ng/transducers" "^8.8.7"
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@thi.ng/base-n@^2.5.14":
-  version "2.5.14"
-  resolved "https://registry.yarnpkg.com/@thi.ng/base-n/-/base-n-2.5.14.tgz#885bfbc9a68de835a9f30e7e4a2a2399c1ff610f"
-  integrity sha512-2tVN3od67nIi67x4L004jTBWaEbYfAbXKBc503Sa9DIBboiY1IsOaXT67wz68F+ZS3hPEHBxf01nGbytG5Hdyg==
+  "integrity" "sha512-2tVN3od67nIi67x4L004jTBWaEbYfAbXKBc503Sa9DIBboiY1IsOaXT67wz68F+ZS3hPEHBxf01nGbytG5Hdyg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/base-n/-/base-n-2.5.14.tgz"
+  "version" "2.5.14"
 
 "@thi.ng/binary@^3.3.35":
-  version "3.3.35"
-  resolved "https://registry.yarnpkg.com/@thi.ng/binary/-/binary-3.3.35.tgz#bb607a582b3119e7310eacf8f30b719bb4ffd903"
-  integrity sha512-Q36MewH9mNCSl/m4MSlkbDdzke2I74we0akgl/fQE9qY7Uz1vf2Z/khIGuNW34DfLI9nvFAVMltWJs7woCiXeA==
+  "integrity" "sha512-Q36MewH9mNCSl/m4MSlkbDdzke2I74we0akgl/fQE9qY7Uz1vf2Z/khIGuNW34DfLI9nvFAVMltWJs7woCiXeA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/binary/-/binary-3.3.35.tgz"
+  "version" "3.3.35"
   dependencies:
     "@thi.ng/api" "^8.9.6"
 
 "@thi.ng/checks@^3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@thi.ng/checks/-/checks-3.4.6.tgz#ea53238bc0d54c024a20ea17f27ada25dea123a2"
-  integrity sha512-WiYzysSk826b8TgruFZaLYVxVeDLjg8liuqZKWb0QJM5wb0Si2sf/cGvvHcAnup+g5DUtyz2ib3XEzW9O5Lxtw==
+  "integrity" "sha512-WiYzysSk826b8TgruFZaLYVxVeDLjg8liuqZKWb0QJM5wb0Si2sf/cGvvHcAnup+g5DUtyz2ib3XEzW9O5Lxtw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/checks/-/checks-3.4.6.tgz"
+  "version" "3.4.6"
   dependencies:
-    tslib "^2.6.2"
+    "tslib" "^2.6.2"
 
 "@thi.ng/color@^5.5.28":
-  version "5.5.28"
-  resolved "https://registry.yarnpkg.com/@thi.ng/color/-/color-5.5.28.tgz#7375d5fa647f27c9975a8819568066e80a387d0e"
-  integrity sha512-aMmgWO9sNVki/qwJGcVwm3SWJc5GRT0xl0BpdKXvk6jShi79yTKiCAoQJNMxFVl/7ZyPwdl3c85XGKXZOYiAFQ==
+  "integrity" "sha512-aMmgWO9sNVki/qwJGcVwm3SWJc5GRT0xl0BpdKXvk6jShi79yTKiCAoQJNMxFVl/7ZyPwdl3c85XGKXZOYiAFQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/color/-/color-5.5.28.tgz"
+  "version" "5.5.28"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/arrays" "^2.7.1"
@@ -264,33 +159,33 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/compare@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@thi.ng/compare/-/compare-2.2.2.tgz#b608b4b0c9eb7f70cbf3a3a0856e5517b812b029"
-  integrity sha512-b/neQjSxWSkhAb38vE1yQhW1VOfJHKlyfuryXCJRHEmcJUtdaD1sFxyCo0VnbJk2PFcSqAJTwV5sxlhKYSmDog==
+  "integrity" "sha512-b/neQjSxWSkhAb38vE1yQhW1VOfJHKlyfuryXCJRHEmcJUtdaD1sFxyCo0VnbJk2PFcSqAJTwV5sxlhKYSmDog=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/compare/-/compare-2.2.2.tgz"
+  "version" "2.2.2"
   dependencies:
     "@thi.ng/api" "^8.9.6"
 
 "@thi.ng/compose@^2.1.45":
-  version "2.1.45"
-  resolved "https://registry.yarnpkg.com/@thi.ng/compose/-/compose-2.1.45.tgz#e56bac1dadd245437f89bcfd59ec9976596e0ef8"
-  integrity sha512-u4+0j4YOoOLyV1UPvJQQK/a+8MFh8MsvSP4I2ViyZ09vjdPQY8vC+LbbS1eZ8w4EQBtuGYXIi5g2nwfdS8O4WA==
+  "integrity" "sha512-u4+0j4YOoOLyV1UPvJQQK/a+8MFh8MsvSP4I2ViyZ09vjdPQY8vC+LbbS1eZ8w4EQBtuGYXIi5g2nwfdS8O4WA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/compose/-/compose-2.1.45.tgz"
+  "version" "2.1.45"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/errors" "^2.4.0"
 
 "@thi.ng/date@^2.4.25":
-  version "2.4.25"
-  resolved "https://registry.yarnpkg.com/@thi.ng/date/-/date-2.4.25.tgz#e48ba937c688f38f26716714b4edbb09fbd1e964"
-  integrity sha512-sBBxa+4Ia9N4mDtHyPXwKWSmMZwUBX5419qXSf+m3MhxNYusmp8olg5+XD+s2BPeYS59ojtL5PcoCLTYVdIQZA==
+  "integrity" "sha512-sBBxa+4Ia9N4mDtHyPXwKWSmMZwUBX5419qXSf+m3MhxNYusmp8olg5+XD+s2BPeYS59ojtL5PcoCLTYVdIQZA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/date/-/date-2.4.25.tgz"
+  "version" "2.4.25"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/strings" "^3.6.3"
 
 "@thi.ng/dcons@^3.2.69":
-  version "3.2.69"
-  resolved "https://registry.yarnpkg.com/@thi.ng/dcons/-/dcons-3.2.69.tgz#7587c596f6af9438aad5487e0447cdd5d4f3eb86"
-  integrity sha512-taYmOcvewsyGp+s8f7JZksHCtwcis3x3XS5qAv+h09hETK2jApmSWUbKKz9fOdZ3YQ6c9s++ouJhMpYgxJs2Qw==
+  "integrity" "sha512-taYmOcvewsyGp+s8f7JZksHCtwcis3x3XS5qAv+h09hETK2jApmSWUbKKz9fOdZ3YQ6c9s++ouJhMpYgxJs2Qw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/dcons/-/dcons-3.2.69.tgz"
+  "version" "3.2.69"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -301,18 +196,18 @@
     "@thi.ng/transducers" "^8.8.7"
 
 "@thi.ng/defmulti@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@thi.ng/defmulti/-/defmulti-3.0.3.tgz#d3912e1860ec881852b33696b325c134b3c0ffb7"
-  integrity sha512-QM0AtGeXxUbKs2A8CP01Mb13J7FXael0bCirCuUnMjmGKdCeGzzeeBwG/H2osv6fctBeHxFjfF30szxBp5J1lA==
+  "integrity" "sha512-QM0AtGeXxUbKs2A8CP01Mb13J7FXael0bCirCuUnMjmGKdCeGzzeeBwG/H2osv6fctBeHxFjfF30szxBp5J1lA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/defmulti/-/defmulti-3.0.3.tgz"
+  "version" "3.0.3"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/errors" "^2.4.0"
     "@thi.ng/logger" "^1.4.22"
 
 "@thi.ng/distance@^2.4.26":
-  version "2.4.26"
-  resolved "https://registry.yarnpkg.com/@thi.ng/distance/-/distance-2.4.26.tgz#7dab6c5f60cbd3a24bb913109f2ce7d1794f2c5e"
-  integrity sha512-ofQ0SLWGlpXq8hC7rXRuROnchSV/OmIrs3KD1B4Og711+VpFV+ENbFzQ7hRf+5oWycQn0UQPE5lN4HxZVdzwVw==
+  "integrity" "sha512-ofQ0SLWGlpXq8hC7rXRuROnchSV/OmIrs3KD1B4Og711+VpFV+ENbFzQ7hRf+5oWycQn0UQPE5lN4HxZVdzwVw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/distance/-/distance-2.4.26.tgz"
+  "version" "2.4.26"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -322,41 +217,41 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/dl-asset@^2.3.45":
-  version "2.3.45"
-  resolved "https://registry.yarnpkg.com/@thi.ng/dl-asset/-/dl-asset-2.3.45.tgz#3aaef6100b3b7b0e8a301151d48d423f19b59ab7"
-  integrity sha512-KGkm5p7CzZl2UMnz9ApWlgGZsQttM3+n27dHV8oPfvl8qv6sXuG4SfJvELW1+rHZ8REM5AYTBU4r6isCJg+bQA==
+  "integrity" "sha512-KGkm5p7CzZl2UMnz9ApWlgGZsQttM3+n27dHV8oPfvl8qv6sXuG4SfJvELW1+rHZ8REM5AYTBU4r6isCJg+bQA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/dl-asset/-/dl-asset-2.3.45.tgz"
+  "version" "2.3.45"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/mime" "^2.2.26"
 
 "@thi.ng/equiv@^2.1.31":
-  version "2.1.31"
-  resolved "https://registry.yarnpkg.com/@thi.ng/equiv/-/equiv-2.1.31.tgz#048bc082b3feacae6878fa1cb1ca4c667d7e85fd"
-  integrity sha512-EFyLyTnxL9zkWvXUT39+2RweZn1iq/zZAdRne4LkwBO5c8Psl3vxTpHxoe+WZQe3/iaGqJlNky9yauozkmdviQ==
+  "integrity" "sha512-EFyLyTnxL9zkWvXUT39+2RweZn1iq/zZAdRne4LkwBO5c8Psl3vxTpHxoe+WZQe3/iaGqJlNky9yauozkmdviQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/equiv/-/equiv-2.1.31.tgz"
+  "version" "2.1.31"
 
 "@thi.ng/errors@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@thi.ng/errors/-/errors-2.4.0.tgz#4ed4420f5fd9ec86c48e111767d28fcdf342550f"
-  integrity sha512-B80KXWH/dCXoAg116CuVk2HCTt4EWMre3H5Tf+mhS7Kb4ao9P0CnqGWni07oDN/8p6sJqFM+PS0NCGD0JZDOnA==
+  "integrity" "sha512-B80KXWH/dCXoAg116CuVk2HCTt4EWMre3H5Tf+mhS7Kb4ao9P0CnqGWni07oDN/8p6sJqFM+PS0NCGD0JZDOnA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/errors/-/errors-2.4.0.tgz"
+  "version" "2.4.0"
 
 "@thi.ng/expose@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@thi.ng/expose/-/expose-1.2.2.tgz#96588e56d71bf1cd020dbc308149da9b8e5c4caa"
-  integrity sha512-4AHCR+KhIrEikqfJqR9ljRtWGU8dULp/DnuwhPkLeUawjXY2CPkdnoaE+uZIAeJ5YNXN2aVVtaKGwiEfW0OLPQ==
+  "integrity" "sha512-4AHCR+KhIrEikqfJqR9ljRtWGU8dULp/DnuwhPkLeUawjXY2CPkdnoaE+uZIAeJ5YNXN2aVVtaKGwiEfW0OLPQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/expose/-/expose-1.2.2.tgz"
+  "version" "1.2.2"
 
 "@thi.ng/geom-api@^3.4.42":
-  version "3.4.42"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-api/-/geom-api-3.4.42.tgz#d23b4f63b4c9c13e1551cceae1e6942465c8f318"
-  integrity sha512-QNj0Q7ksLyMk1tNeDgkPOnu67aDeqd0QUOK5iPq5TVBnXfFMT9ZZ78ej56yM7A9YeCq96Jdtl3R2Y1xHQcCv2Q==
+  "integrity" "sha512-QNj0Q7ksLyMk1tNeDgkPOnu67aDeqd0QUOK5iPq5TVBnXfFMT9ZZ78ej56yM7A9YeCq96Jdtl3R2Y1xHQcCv2Q=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-api/-/geom-api-3.4.42.tgz"
+  "version" "3.4.42"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-arc@^2.1.85":
-  version "2.1.85"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-arc/-/geom-arc-2.1.85.tgz#dd2fe8437dc571918520b12e186f589bc517385c"
-  integrity sha512-KaYuA+oT4j4gtJEoGrpUXs6f+38XfHYdNNHSi2HXdfddM/i/nxHI+SZVK1EBRDtSVnW0M+ORSH5ij/9EMZRhSw==
+  "integrity" "sha512-KaYuA+oT4j4gtJEoGrpUXs6f+38XfHYdNNHSi2HXdfddM/i/nxHI+SZVK1EBRDtSVnW0M+ORSH5ij/9EMZRhSw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-arc/-/geom-arc-2.1.85.tgz"
+  "version" "2.1.85"
   dependencies:
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/geom-api" "^3.4.42"
@@ -365,18 +260,18 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-clip-line@^2.3.42":
-  version "2.3.42"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-clip-line/-/geom-clip-line-2.3.42.tgz#4ab63f7fa00d33f9c6068db422be7351a4d82fe3"
-  integrity sha512-4fkDP34hY7ndq8ycchPviVWE5o434C5n782AnVLvuknc+GKQxlSyfgGF3veq0x0SYswBghKsTFCxqMLOUJPcOw==
+  "integrity" "sha512-4fkDP34hY7ndq8ycchPviVWE5o434C5n782AnVLvuknc+GKQxlSyfgGF3veq0x0SYswBghKsTFCxqMLOUJPcOw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-clip-line/-/geom-clip-line-2.3.42.tgz"
+  "version" "2.3.42"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/geom-isec" "^2.1.84"
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-clip-poly@^2.1.84":
-  version "2.1.84"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-clip-poly/-/geom-clip-poly-2.1.84.tgz#2e64d176d326414f5ac90b062428e69ea421d643"
-  integrity sha512-p51F54YWwxa83+4nzL13MQ1cGX2G7qB2ZhcRvG+8gWrWT5Lu4FE/ii2RyCmLKJEhCqf1+fO8mM++Ua1X81y04g==
+  "integrity" "sha512-p51F54YWwxa83+4nzL13MQ1cGX2G7qB2ZhcRvG+8gWrWT5Lu4FE/ii2RyCmLKJEhCqf1+fO8mM++Ua1X81y04g=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-clip-poly/-/geom-clip-poly-2.1.84.tgz"
+  "version" "2.1.84"
   dependencies:
     "@thi.ng/geom-isec" "^2.1.84"
     "@thi.ng/geom-poly-utils" "^2.3.68"
@@ -384,26 +279,26 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-closest-point@^2.1.80":
-  version "2.1.80"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-closest-point/-/geom-closest-point-2.1.80.tgz#927f0f43163f2f3f887abc2f3dc7b370f715f482"
-  integrity sha512-/++bo7n8txXXa79IAXKjBn2E4s8WMkmsytR6VWZ3pii68dIf3URO8ibC0dlWLGjgTyq8i57Nk7yH0pJLeWm3FA==
+  "integrity" "sha512-/++bo7n8txXXa79IAXKjBn2E4s8WMkmsytR6VWZ3pii68dIf3URO8ibC0dlWLGjgTyq8i57Nk7yH0pJLeWm3FA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-closest-point/-/geom-closest-point-2.1.80.tgz"
+  "version" "2.1.80"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/math" "^5.7.1"
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-hull@^2.1.80":
-  version "2.1.80"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-hull/-/geom-hull-2.1.80.tgz#ee958d2b0745c095e8949d5e79d74945a322e7fc"
-  integrity sha512-Z/Q6FfxHOWXK/cQyneRCx78qSddsmE2+IUmCKxyxeVwcMLWnl91FRcQ4/Cu7Bf3xTbO7hPMyvWbs1jVD/B13jQ==
+  "integrity" "sha512-Z/Q6FfxHOWXK/cQyneRCx78qSddsmE2+IUmCKxyxeVwcMLWnl91FRcQ4/Cu7Bf3xTbO7hPMyvWbs1jVD/B13jQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-hull/-/geom-hull-2.1.80.tgz"
+  "version" "2.1.80"
   dependencies:
     "@thi.ng/math" "^5.7.1"
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-isec@^2.1.84":
-  version "2.1.84"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-isec/-/geom-isec-2.1.84.tgz#1f62faed3dbf81b847731d9841c25f4a4d3945f5"
-  integrity sha512-HCDJe2TNjJju/NWjF4CPxmyf5nutHYT9Bui0uKdAF1pFcAN7o6tVTQXcSRXLcy0sWlfyDA33uRDg2ZNjC2G2cw==
+  "integrity" "sha512-HCDJe2TNjJju/NWjF4CPxmyf5nutHYT9Bui0uKdAF1pFcAN7o6tVTQXcSRXLcy0sWlfyDA33uRDg2ZNjC2G2cw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-isec/-/geom-isec-2.1.84.tgz"
+  "version" "2.1.84"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/geom-api" "^3.4.42"
@@ -412,9 +307,9 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-poly-utils@^2.3.68":
-  version "2.3.68"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-poly-utils/-/geom-poly-utils-2.3.68.tgz#62d901d079aeb1848d67b660bd347b264993b9d7"
-  integrity sha512-0FMJclHk4NAbIn/FjIcfU34WETWfCvWNZxxu8m6LyeGfyViQFGyyvDe4dEJ6VrGkfQi/+6KPr3GDX4UIQg93Fw==
+  "integrity" "sha512-0FMJclHk4NAbIn/FjIcfU34WETWfCvWNZxxu8m6LyeGfyViQFGyyvDe4dEJ6VrGkfQi/+6KPr3GDX4UIQg93Fw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-poly-utils/-/geom-poly-utils-2.3.68.tgz"
+  "version" "2.3.68"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/errors" "^2.4.0"
@@ -423,9 +318,9 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-resample@^2.3.6":
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-resample/-/geom-resample-2.3.6.tgz#124467fe2c670bc9f2d41d5ae11240f810291f52"
-  integrity sha512-GZfn1z1UMDeFEyO5a2KxXDqkr2/xm0qhsY42lpst8ai4l7jLCS2ucB/eOS354EXtjz20JXklGF+F3pmv/C17Gg==
+  "integrity" "sha512-GZfn1z1UMDeFEyO5a2KxXDqkr2/xm0qhsY42lpst8ai4l7jLCS2ucB/eOS354EXtjz20JXklGF+F3pmv/C17Gg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-resample/-/geom-resample-2.3.6.tgz"
+  "version" "2.3.6"
   dependencies:
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/geom-api" "^3.4.42"
@@ -435,9 +330,9 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-splines@^2.2.59":
-  version "2.2.59"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-splines/-/geom-splines-2.2.59.tgz#021f9ef9c456d9cf3a5c7067f47725ef9cc6e45b"
-  integrity sha512-75nZHbN+2tBkHiF+SHU+Pn78LbSqOBkbChEd5uzHFqebEiQDwoBX1BnWxcDcy4qzZWkzF/6ulkxZBDk88spiQQ==
+  "integrity" "sha512-75nZHbN+2tBkHiF+SHU+Pn78LbSqOBkbChEd5uzHFqebEiQDwoBX1BnWxcDcy4qzZWkzF/6ulkxZBDk88spiQQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-splines/-/geom-splines-2.2.59.tgz"
+  "version" "2.2.59"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -448,9 +343,9 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-subdiv-curve@^2.1.84":
-  version "2.1.84"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-subdiv-curve/-/geom-subdiv-curve-2.1.84.tgz#d9b323f9a5075f17382a867e43adfbdaf6590580"
-  integrity sha512-0OenSOXuNAB8UDY95QPAbX4s+yG8YpVCYpwAZMUeqNCS/z/BoUNbw/UA9YooDNR+3OrS24XZn44S8WB6IC/1WA==
+  "integrity" "sha512-0OenSOXuNAB8UDY95QPAbX4s+yG8YpVCYpwAZMUeqNCS/z/BoUNbw/UA9YooDNR+3OrS24XZn44S8WB6IC/1WA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-subdiv-curve/-/geom-subdiv-curve-2.1.84.tgz"
+  "version" "2.1.84"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/geom-api" "^3.4.42"
@@ -458,9 +353,9 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom-tessellate@^2.1.84":
-  version "2.1.84"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom-tessellate/-/geom-tessellate-2.1.84.tgz#ee0c46fc3d372084deb9f0abd6df07d5f1d2fa8a"
-  integrity sha512-xnviDbB6okRDvP49PdaVYiAkF/4w0lpOGUxVpxTz2bo6Wkja5OIX2FcTujHJpxr12Dscz1hm2eQVTGiHCYiZCw==
+  "integrity" "sha512-xnviDbB6okRDvP49PdaVYiAkF/4w0lpOGUxVpxTz2bo6Wkja5OIX2FcTujHJpxr12Dscz1hm2eQVTGiHCYiZCw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom-tessellate/-/geom-tessellate-2.1.84.tgz"
+  "version" "2.1.84"
   dependencies:
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/geom-api" "^3.4.42"
@@ -470,9 +365,9 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/geom@^5.2.14":
-  version "5.2.14"
-  resolved "https://registry.yarnpkg.com/@thi.ng/geom/-/geom-5.2.14.tgz#39e4b72c62f26bcc8eb4bcd6d571ecec08ee8873"
-  integrity sha512-eaUXEoX5Dkz+9kMGiPaFQISvXwaQzN8izJxYoQqGrHFyHUEtsW45mNYDXrbxhftUFWC9sPu+StjHqpoKwttjEA==
+  "integrity" "sha512-eaUXEoX5Dkz+9kMGiPaFQISvXwaQzN8izJxYoQqGrHFyHUEtsW45mNYDXrbxhftUFWC9sPu+StjHqpoKwttjEA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/geom/-/geom-5.2.14.tgz"
+  "version" "5.2.14"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/arrays" "^2.7.1"
@@ -503,23 +398,23 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/heaps@^2.1.42":
-  version "2.1.42"
-  resolved "https://registry.yarnpkg.com/@thi.ng/heaps/-/heaps-2.1.42.tgz#7626a636159b10ab455fdf84f41760ccd14b19a2"
-  integrity sha512-5tBsI4zkGOJNL7kXIiy725pjzb3pAwQ9YbTL0iy84nSFpxdpe2ybOMkfV12VvcIa7EquH/wfnOfUVWu1QuDbjQ==
+  "integrity" "sha512-5tBsI4zkGOJNL7kXIiy725pjzb3pAwQ9YbTL0iy84nSFpxdpe2ybOMkfV12VvcIa7EquH/wfnOfUVWu1QuDbjQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/heaps/-/heaps-2.1.42.tgz"
+  "version" "2.1.42"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/compare" "^2.2.2"
     "@thi.ng/equiv" "^2.1.31"
 
 "@thi.ng/hex@^2.3.18":
-  version "2.3.18"
-  resolved "https://registry.yarnpkg.com/@thi.ng/hex/-/hex-2.3.18.tgz#4931a0b71e05204c2bb7f42f5f8c60d3ba51f295"
-  integrity sha512-FGq/P7cfaTWCd+NsnRPTE0aRuB5r10Hma5Jkys+1UKEaVj3OYuCUa3s1dcOT4oMbOqXuUnqH2fxAtUqMRrcWtg==
+  "integrity" "sha512-FGq/P7cfaTWCd+NsnRPTE0aRuB5r10Hma5Jkys+1UKEaVj3OYuCUa3s1dcOT4oMbOqXuUnqH2fxAtUqMRrcWtg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/hex/-/hex-2.3.18.tgz"
+  "version" "2.3.18"
 
 "@thi.ng/hiccup-canvas@^2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@thi.ng/hiccup-canvas/-/hiccup-canvas-2.4.4.tgz#8d05d7034e9d36e183787c764b919a045f191800"
-  integrity sha512-/9rfyRl78yTiCaNrD2pLbCqN/o7wtsb1IXcQSZTI//saRTyY9R6NJX83+yMlPuNF40fOnK/G07S8epd2pB9K1w==
+  "integrity" "sha512-/9rfyRl78yTiCaNrD2pLbCqN/o7wtsb1IXcQSZTI//saRTyY9R6NJX83+yMlPuNF40fOnK/G07S8epd2pB9K1w=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/hiccup-canvas/-/hiccup-canvas-2.4.4.tgz"
+  "version" "2.4.4"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -529,18 +424,18 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/hiccup-svg@^5.0.30":
-  version "5.0.30"
-  resolved "https://registry.yarnpkg.com/@thi.ng/hiccup-svg/-/hiccup-svg-5.0.30.tgz#f80dd7eff96a78dbefcf5baf9fdce00c70373329"
-  integrity sha512-vSG4Mg1U+jPjFZaNV8DsoNb7EtxxKEjdQbt/ZKzzR+xNXnDMnLT5faJgHsGYq6c5r/4yK50FJcpguRgezK8FmQ==
+  "integrity" "sha512-vSG4Mg1U+jPjFZaNV8DsoNb7EtxxKEjdQbt/ZKzzR+xNXnDMnLT5faJgHsGYq6c5r/4yK50FJcpguRgezK8FmQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/hiccup-svg/-/hiccup-svg-5.0.30.tgz"
+  "version" "5.0.30"
   dependencies:
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/color" "^5.5.28"
     "@thi.ng/prefixes" "^2.2.2"
 
 "@thi.ng/hiccup@^5.0.4":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@thi.ng/hiccup/-/hiccup-5.0.4.tgz#77bf178118612c95ae0d4bd0f2fe6f28b28e027b"
-  integrity sha512-ZmNLidsOceE1BM36u2Ojxy8uILfOHVMIWE0i7x1lEWJvZGMK94FSepBFHJpF51HLAmg6VHus9fT8MUzfZH1ZAA==
+  "integrity" "sha512-ZmNLidsOceE1BM36u2Ojxy8uILfOHVMIWE0i7x1lEWJvZGMK94FSepBFHJpF51HLAmg6VHus9fT8MUzfZH1ZAA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/hiccup/-/hiccup-5.0.4.tgz"
+  "version" "5.0.4"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -548,9 +443,9 @@
     "@thi.ng/strings" "^3.6.3"
 
 "@thi.ng/k-means@^0.6.41":
-  version "0.6.41"
-  resolved "https://registry.yarnpkg.com/@thi.ng/k-means/-/k-means-0.6.41.tgz#2658e32cb735e40f0f57df0ac4511194945ebb00"
-  integrity sha512-50JW+XCTE6OZdGztM/dfrWQeoaqXDQpmrD6zKiAnCWzG/2r9RaEcBy6MdfQHhnprX9zWKLaLqOsw47p8Z0046w==
+  "integrity" "sha512-50JW+XCTE6OZdGztM/dfrWQeoaqXDQpmrD6zKiAnCWzG/2r9RaEcBy6MdfQHhnprX9zWKLaLqOsw47p8Z0046w=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/k-means/-/k-means-0.6.41.tgz"
+  "version" "0.6.41"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/distance" "^2.4.26"
@@ -559,21 +454,21 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/logger@^1.4.22":
-  version "1.4.22"
-  resolved "https://registry.yarnpkg.com/@thi.ng/logger/-/logger-1.4.22.tgz#2796cb7d32d3e30da5ed0d442771c1d278d83d69"
-  integrity sha512-j9wNTtB7N6a4p2D+D2ECsLmrlMBpiheSVKZwJec1kLGJIxxNndck8Y6b26GibbIMHNS98mZoqYs4Nfqmpb8lZg==
+  "integrity" "sha512-j9wNTtB7N6a4p2D+D2ECsLmrlMBpiheSVKZwJec1kLGJIxxNndck8Y6b26GibbIMHNS98mZoqYs4Nfqmpb8lZg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/logger/-/logger-1.4.22.tgz"
+  "version" "1.4.22"
 
 "@thi.ng/math@^5.7.1":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/@thi.ng/math/-/math-5.7.1.tgz#d29cbdfe3f83aa9574964e8a23528f268f895230"
-  integrity sha512-JxkN8tkaVRL2s/bhEGXgfSMNvghry6yaAdhTZ8ZvmuX1hfl/0QP+ThRsZXsrct3SgP45TpjMv3lCN9l/NMNGEg==
+  "integrity" "sha512-JxkN8tkaVRL2s/bhEGXgfSMNvghry6yaAdhTZ8ZvmuX1hfl/0QP+ThRsZXsrct3SgP45TpjMv3lCN9l/NMNGEg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/math/-/math-5.7.1.tgz"
+  "version" "5.7.1"
   dependencies:
     "@thi.ng/api" "^8.9.6"
 
 "@thi.ng/matrices@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@thi.ng/matrices/-/matrices-2.2.4.tgz#36b97b358ceea2b9703bbd323645dd0265e95d22"
-  integrity sha512-J7KH8Imc0zppPraQq5+21qcHx23GU9PelE/XAF2yz2nGbG99Ecn+dDRx2ZKXJ6LqXZaSSGq4ppNnmKcCM4R3vw==
+  "integrity" "sha512-J7KH8Imc0zppPraQq5+21qcHx23GU9PelE/XAF2yz2nGbG99Ecn+dDRx2ZKXJ6LqXZaSSGq4ppNnmKcCM4R3vw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/matrices/-/matrices-2.2.4.tgz"
+  "version" "2.2.4"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -581,30 +476,30 @@
     "@thi.ng/vectors" "^7.8.1"
 
 "@thi.ng/memoize@^3.1.40":
-  version "3.1.40"
-  resolved "https://registry.yarnpkg.com/@thi.ng/memoize/-/memoize-3.1.40.tgz#3a07ad82b7577b883b6449968212c6e420e5c818"
-  integrity sha512-2cGHdbWOMsooBvSXZak1PUlvxY4W+0ZKXTewKQCC2ZD1C/ZNdOS54OugqdNgT/vvyeev9b5AH8nFBgrr8YVoDg==
+  "integrity" "sha512-2cGHdbWOMsooBvSXZak1PUlvxY4W+0ZKXTewKQCC2ZD1C/ZNdOS54OugqdNgT/vvyeev9b5AH8nFBgrr8YVoDg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/memoize/-/memoize-3.1.40.tgz"
+  "version" "3.1.40"
   dependencies:
     "@thi.ng/api" "^8.9.6"
 
 "@thi.ng/mime@^2.2.26":
-  version "2.2.26"
-  resolved "https://registry.yarnpkg.com/@thi.ng/mime/-/mime-2.2.26.tgz#3d24f4e48a520901b28bbe4e22b8a11e3f6b2772"
-  integrity sha512-CK0JF7Te1MtIGg0IfKVs4Nja1lFo1yaKV3S2bAXnPVuXmZ+ow3zx3IZpxRL8yTXn5My9XzBz6r6qJVrkIfFvqg==
+  "integrity" "sha512-CK0JF7Te1MtIGg0IfKVs4Nja1lFo1yaKV3S2bAXnPVuXmZ+ow3zx3IZpxRL8yTXn5My9XzBz6r6qJVrkIfFvqg=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/mime/-/mime-2.2.26.tgz"
+  "version" "2.2.26"
 
 "@thi.ng/paths@^5.1.47":
-  version "5.1.47"
-  resolved "https://registry.yarnpkg.com/@thi.ng/paths/-/paths-5.1.47.tgz#9fdce810e2e7b59f7a8547fa6ebe53079d5bc885"
-  integrity sha512-+Ck5Xz1kgrYkxvdJwXIuY3uKWuUGxoIq3+aHL9Hvyf4sMUKFpYt6WWerMiCtG4RilYFSIzVASFF5O1bUMhxC0A==
+  "integrity" "sha512-+Ck5Xz1kgrYkxvdJwXIuY3uKWuUGxoIq3+aHL9Hvyf4sMUKFpYt6WWerMiCtG4RilYFSIzVASFF5O1bUMhxC0A=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/paths/-/paths-5.1.47.tgz"
+  "version" "5.1.47"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
     "@thi.ng/errors" "^2.4.0"
 
 "@thi.ng/pixel@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@thi.ng/pixel/-/pixel-4.3.1.tgz#37c17f7ac8a8ca5bc4a6744fcdff3060850ed719"
-  integrity sha512-C7rx3za3pP+lFyMHVxrDBhnQ1tu3lCURRV39tMzPr5YcWuZWxhuNF+k+eIt5dit4eHDpHsVIe87pbgYMv5Z2lw==
+  "integrity" "sha512-C7rx3za3pP+lFyMHVxrDBhnQ1tu3lCURRV39tMzPr5YcWuZWxhuNF+k+eIt5dit4eHDpHsVIe87pbgYMv5Z2lw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/pixel/-/pixel-4.3.1.tgz"
+  "version" "4.3.1"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/binary" "^3.3.35"
@@ -616,31 +511,31 @@
     "@thi.ng/porter-duff" "^2.1.46"
 
 "@thi.ng/porter-duff@^2.1.46":
-  version "2.1.46"
-  resolved "https://registry.yarnpkg.com/@thi.ng/porter-duff/-/porter-duff-2.1.46.tgz#28dea985d33e6d6b27d9fce19b15b9df46f5b2f2"
-  integrity sha512-rBPf/9+vofzjtWFq1h+aOt4HeF5vADTZQJjgZ9Ru5DQ5PARZScT/ko5keOEzQ8V/wUskXzvwzo310kjGK73+Ug==
+  "integrity" "sha512-rBPf/9+vofzjtWFq1h+aOt4HeF5vADTZQJjgZ9Ru5DQ5PARZScT/ko5keOEzQ8V/wUskXzvwzo310kjGK73+Ug=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/porter-duff/-/porter-duff-2.1.46.tgz"
+  "version" "2.1.46"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/math" "^5.7.1"
 
 "@thi.ng/prefixes@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@thi.ng/prefixes/-/prefixes-2.2.2.tgz#f106d71fa16f22c4cb315a016479a68c15daf76e"
-  integrity sha512-xHPG1zrDGzJeZ3jHrr1SCNDeVFM7vkD924g6liJ0gSCJ9LXEIQLKhhO4SxwBf3ghuu4nBre9SqruhE6QS9xBEw==
+  "integrity" "sha512-xHPG1zrDGzJeZ3jHrr1SCNDeVFM7vkD924g6liJ0gSCJ9LXEIQLKhhO4SxwBf3ghuu4nBre9SqruhE6QS9xBEw=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/prefixes/-/prefixes-2.2.2.tgz"
+  "version" "2.2.2"
 
-"@thi.ng/random-fxhash@^0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@thi.ng/random-fxhash/-/random-fxhash-0.3.17.tgz#40f7296a39e3d3030723a74495b1d7bbc4b163c5"
-  integrity sha512-wkEA0COqDduc5IkmMv9IML5+b6c75QZyj+2/FZAoqqr/w4Ee2kWXf65E5PAAmFKKb8ZIDlAUk8jDkyiW6fporg==
+"@thi.ng/random-fxhash@^0.3.18":
+  "integrity" "sha512-g82uE75i445i20H3jnF5zEV/lUrNoxol5kHmzsMREIjPEgeunl4zV9U/jAMXz6/dPRkAtWHx98Wt2Mbd1LVoJQ=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/random-fxhash/-/random-fxhash-0.3.18.tgz"
+  "version" "0.3.18"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/base-n" "^2.5.14"
-    "@thi.ng/random" "^3.6.11"
+    "@thi.ng/random" "^3.6.12"
 
-"@thi.ng/random@^3.6.11":
-  version "3.6.11"
-  resolved "https://registry.yarnpkg.com/@thi.ng/random/-/random-3.6.11.tgz#63479f6aa02630484625c91def04d5715db27141"
-  integrity sha512-tKLs3Vsb0eScRvaHOm9S2mWtJDGS6kFaKbx+6msPY/IZ8kZRNX1pIXSAdk70wIpCOVut049V1fJw+Xyrt9rgzw==
+"@thi.ng/random@^3.6.11", "@thi.ng/random@^3.6.12":
+  "integrity" "sha512-UqXQAr3HBJdHgIztOl3I5qXEly3FCuFFqtwBNEhC6+Fj55JgwvVZJJVqGVw1oeWjRH0kplDECkx0N/jQYYBeSA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/random/-/random-3.6.12.tgz"
+  "version" "3.6.12"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -648,9 +543,9 @@
     "@thi.ng/hex" "^2.3.18"
 
 "@thi.ng/resolve-map@^7.1.40":
-  version "7.1.40"
-  resolved "https://registry.yarnpkg.com/@thi.ng/resolve-map/-/resolve-map-7.1.40.tgz#67138ec89a43e6b7a616431a0ac4a49c70a3ed64"
-  integrity sha512-6+Cm8cXkZCqCiacoGS/SLvCUI6QkTGtPRXRWGCHYD6l4s/m7K/Qcc7fNoQ4j7FZiHVVgShPwAWKbR5EqnAQP7A==
+  "integrity" "sha512-6+Cm8cXkZCqCiacoGS/SLvCUI6QkTGtPRXRWGCHYD6l4s/m7K/Qcc7fNoQ4j7FZiHVVgShPwAWKbR5EqnAQP7A=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/resolve-map/-/resolve-map-7.1.40.tgz"
+  "version" "7.1.40"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/checks" "^3.4.6"
@@ -658,9 +553,9 @@
     "@thi.ng/paths" "^5.1.47"
 
 "@thi.ng/strings@^3.6.3":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@thi.ng/strings/-/strings-3.6.3.tgz#391773eb94cf5ee897d0cf55e88d56aa9d4a07d9"
-  integrity sha512-uINfkVpNdR7PkhHnP+VvK+N0halM+VKVghYIkglUFJspc2gO+KaIUPqIjxA4KIooxqVc77aHNk8TjQ8nhNO4fA==
+  "integrity" "sha512-uINfkVpNdR7PkhHnP+VvK+N0halM+VKVghYIkglUFJspc2gO+KaIUPqIjxA4KIooxqVc77aHNk8TjQ8nhNO4fA=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/strings/-/strings-3.6.3.tgz"
+  "version" "3.6.3"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/errors" "^2.4.0"
@@ -668,9 +563,9 @@
     "@thi.ng/memoize" "^3.1.40"
 
 "@thi.ng/transducers@^8.8.7":
-  version "8.8.7"
-  resolved "https://registry.yarnpkg.com/@thi.ng/transducers/-/transducers-8.8.7.tgz#0b1b29bf0641682f4533374c0cb416c3de4fd422"
-  integrity sha512-FKQX0r6PmMZgMTmQaQBJn3329rNqYVjMuNClcrIE90fb7C70XnO3EHpqLlDL9e0Y7SlGVGMu3AkNRfDWDJLO8g==
+  "integrity" "sha512-FKQX0r6PmMZgMTmQaQBJn3329rNqYVjMuNClcrIE90fb7C70XnO3EHpqLlDL9e0Y7SlGVGMu3AkNRfDWDJLO8g=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/transducers/-/transducers-8.8.7.tgz"
+  "version" "8.8.7"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/arrays" "^2.7.1"
@@ -682,9 +577,9 @@
     "@thi.ng/random" "^3.6.11"
 
 "@thi.ng/vectors@^7.8.1":
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/@thi.ng/vectors/-/vectors-7.8.1.tgz#c143ff9fc2570d38b45fb06836176d3d30734f68"
-  integrity sha512-gScg6uC5XUJkGCko8Z1/5ejN07dQA0YEX30lPjyphmudxYX7ER2zi3Pvs6gmYZ4gbbc4nUFkokVKzZhjrgrF/Q==
+  "integrity" "sha512-gScg6uC5XUJkGCko8Z1/5ejN07dQA0YEX30lPjyphmudxYX7ER2zi3Pvs6gmYZ4gbbc4nUFkokVKzZhjrgrF/Q=="
+  "resolved" "https://registry.npmjs.org/@thi.ng/vectors/-/vectors-7.8.1.tgz"
+  "version" "7.8.1"
   dependencies:
     "@thi.ng/api" "^8.9.6"
     "@thi.ng/binary" "^3.3.35"
@@ -698,378 +593,378 @@
     "@thi.ng/transducers" "^8.8.7"
 
 "@trysound/sax@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
-  integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+  "integrity" "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+  "resolved" "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
+  "version" "0.2.0"
 
-"@types/node@20.8.10":
-  version "20.8.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
-  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
+"@types/node@>= 14", "@types/node@20.8.10":
+  "integrity" "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w=="
+  "resolved" "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz"
+  "version" "20.8.10"
   dependencies:
-    undici-types "~5.26.4"
+    "undici-types" "~5.26.4"
 
-acorn@^8.5.0:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
-  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
+"acorn@^8.5.0":
+  "integrity" "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+  "resolved" "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
+  "version" "8.8.2"
 
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+"ansi-styles@^4.1.0":
+  "integrity" "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="
+  "resolved" "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  "version" "4.3.0"
   dependencies:
-    color-convert "^2.0.1"
+    "color-convert" "^2.0.1"
 
-async@^3.2.3:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
-  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+"async@^3.2.3":
+  "integrity" "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+  "resolved" "https://registry.npmjs.org/async/-/async-3.2.4.tgz"
+  "version" "3.2.4"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+"balanced-match@^1.0.0":
+  "integrity" "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+  "resolved" "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
+  "version" "1.0.2"
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+"boolbase@^1.0.0":
+  "integrity" "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+  "resolved" "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+  "version" "1.0.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+"brace-expansion@^1.1.7":
+  "integrity" "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="
+  "resolved" "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
+  "version" "1.1.11"
   dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
+    "balanced-match" "^1.0.0"
+    "concat-map" "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+"brace-expansion@^2.0.1":
+  "integrity" "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="
+  "resolved" "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz"
+  "version" "2.0.1"
   dependencies:
-    balanced-match "^1.0.0"
+    "balanced-match" "^1.0.0"
 
-braces@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+"braces@^3.0.2":
+  "integrity" "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A=="
+  "resolved" "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
+  "version" "3.0.2"
   dependencies:
-    fill-range "^7.0.1"
+    "fill-range" "^7.0.1"
 
-browserslist@^4.0.0, browserslist@^4.21.4:
-  version "4.21.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
-  integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
+"browserslist@^4.0.0", "browserslist@^4.21.4", "browserslist@>= 4.21.0":
+  "integrity" "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w=="
+  "resolved" "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz"
+  "version" "4.21.5"
   dependencies:
-    caniuse-lite "^1.0.30001449"
-    electron-to-chromium "^1.4.284"
-    node-releases "^2.0.8"
-    update-browserslist-db "^1.0.10"
+    "caniuse-lite" "^1.0.30001449"
+    "electron-to-chromium" "^1.4.284"
+    "node-releases" "^2.0.8"
+    "update-browserslist-db" "^1.0.10"
 
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+"buffer-from@^1.0.0":
+  "integrity" "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+  "resolved" "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
+  "version" "1.1.2"
 
-camel-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
-  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+"camel-case@^4.1.2":
+  "integrity" "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw=="
+  "resolved" "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz"
+  "version" "4.1.2"
   dependencies:
-    pascal-case "^3.1.2"
-    tslib "^2.0.3"
+    "pascal-case" "^3.1.2"
+    "tslib" "^2.0.3"
 
-caniuse-api@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
-  integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
+"caniuse-api@^3.0.0":
+  "integrity" "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw=="
+  "resolved" "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz"
+  "version" "3.0.0"
   dependencies:
-    browserslist "^4.0.0"
-    caniuse-lite "^1.0.0"
-    lodash.memoize "^4.1.2"
-    lodash.uniq "^4.5.0"
+    "browserslist" "^4.0.0"
+    "caniuse-lite" "^1.0.0"
+    "lodash.memoize" "^4.1.2"
+    "lodash.uniq" "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001449:
-  version "1.0.30001485"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz#026bb7319f1e483391872dc303a973d4f513f619"
-  integrity sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA==
+"caniuse-lite@^1.0.0", "caniuse-lite@^1.0.30001449":
+  "integrity" "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA=="
+  "resolved" "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz"
+  "version" "1.0.30001485"
 
-chalk@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+"chalk@^4.0.2":
+  "integrity" "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="
+  "resolved" "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  "version" "4.1.2"
   dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
+    "ansi-styles" "^4.1.0"
+    "supports-color" "^7.1.0"
 
-clean-css@^5.2.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.2.tgz#70ecc7d4d4114921f5d298349ff86a31a9975224"
-  integrity sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==
+"clean-css@^5.2.2":
+  "integrity" "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww=="
+  "resolved" "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz"
+  "version" "5.3.2"
   dependencies:
-    source-map "~0.6.0"
+    "source-map" "~0.6.0"
 
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
-  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+"color-convert@^2.0.1":
+  "integrity" "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="
+  "resolved" "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
+  "version" "2.0.1"
   dependencies:
-    color-name "~1.1.4"
+    "color-name" "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+"color-name@~1.1.4":
+  "integrity" "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+  "resolved" "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  "version" "1.1.4"
 
-colord@^2.9.1:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
-  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
+"colord@^2.9.1":
+  "integrity" "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
+  "resolved" "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz"
+  "version" "2.9.3"
 
-colorette@^2.0.16:
-  version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
-  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+"colorette@^2.0.16":
+  "integrity" "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+  "resolved" "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
+  "version" "2.0.20"
 
-commander@^2.20.0:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+"commander@^2.20.0":
+  "integrity" "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+  "resolved" "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
+  "version" "2.20.3"
 
-commander@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+"commander@^7.2.0":
+  "integrity" "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+  "resolved" "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz"
+  "version" "7.2.0"
 
-commander@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+"commander@^8.3.0":
+  "integrity" "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+  "resolved" "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz"
+  "version" "8.3.0"
 
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+"concat-map@0.0.1":
+  "integrity" "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+  "resolved" "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+  "version" "0.0.1"
 
-connect-history-api-fallback@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
-  integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+"connect-history-api-fallback@^1.6.0":
+  "integrity" "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
+  "resolved" "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz"
+  "version" "1.6.0"
 
-consola@^2.15.3:
-  version "2.15.3"
-  resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
-  integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
+"consola@^2.15.3":
+  "integrity" "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+  "resolved" "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz"
+  "version" "2.15.3"
 
-css-declaration-sorter@^6.3.1:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz#630618adc21724484b3e9505bce812def44000ad"
-  integrity sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==
+"css-declaration-sorter@^6.3.1":
+  "integrity" "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew=="
+  "resolved" "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz"
+  "version" "6.4.0"
 
-css-select@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
-  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
+"css-select@^4.2.1":
+  "integrity" "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ=="
+  "resolved" "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz"
+  "version" "4.3.0"
   dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.0.1"
-    domhandler "^4.3.1"
-    domutils "^2.8.0"
-    nth-check "^2.0.1"
+    "boolbase" "^1.0.0"
+    "css-what" "^6.0.1"
+    "domhandler" "^4.3.1"
+    "domutils" "^2.8.0"
+    "nth-check" "^2.0.1"
 
-css-select@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
-  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+"css-select@^5.1.0":
+  "integrity" "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg=="
+  "resolved" "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz"
+  "version" "5.1.0"
   dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
+    "boolbase" "^1.0.0"
+    "css-what" "^6.1.0"
+    "domhandler" "^5.0.2"
+    "domutils" "^3.0.1"
+    "nth-check" "^2.0.1"
 
-css-tree@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
-  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+"css-tree@^2.2.1":
+  "integrity" "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw=="
+  "resolved" "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz"
+  "version" "2.3.1"
   dependencies:
-    mdn-data "2.0.30"
-    source-map-js "^1.0.1"
+    "mdn-data" "2.0.30"
+    "source-map-js" "^1.0.1"
 
-css-tree@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.2.1.tgz#36115d382d60afd271e377f9c5f67d02bd48c032"
-  integrity sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==
+"css-tree@~2.2.0":
+  "integrity" "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="
+  "resolved" "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz"
+  "version" "2.2.1"
   dependencies:
-    mdn-data "2.0.28"
-    source-map-js "^1.0.1"
+    "mdn-data" "2.0.28"
+    "source-map-js" "^1.0.1"
 
-css-what@^6.0.1, css-what@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
-  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+"css-what@^6.0.1", "css-what@^6.1.0":
+  "integrity" "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+  "resolved" "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz"
+  "version" "6.1.0"
 
-cssesc@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
-  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+"cssesc@^3.0.0":
+  "integrity" "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+  "resolved" "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
+  "version" "3.0.0"
 
-cssnano-preset-default@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz#2a93247140d214ddb9f46bc6a3562fa9177fe301"
-  integrity sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==
+"cssnano-preset-default@^6.0.1":
+  "integrity" "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ=="
+  "resolved" "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz"
+  "version" "6.0.1"
   dependencies:
-    css-declaration-sorter "^6.3.1"
-    cssnano-utils "^4.0.0"
-    postcss-calc "^9.0.0"
-    postcss-colormin "^6.0.0"
-    postcss-convert-values "^6.0.0"
-    postcss-discard-comments "^6.0.0"
-    postcss-discard-duplicates "^6.0.0"
-    postcss-discard-empty "^6.0.0"
-    postcss-discard-overridden "^6.0.0"
-    postcss-merge-longhand "^6.0.0"
-    postcss-merge-rules "^6.0.1"
-    postcss-minify-font-values "^6.0.0"
-    postcss-minify-gradients "^6.0.0"
-    postcss-minify-params "^6.0.0"
-    postcss-minify-selectors "^6.0.0"
-    postcss-normalize-charset "^6.0.0"
-    postcss-normalize-display-values "^6.0.0"
-    postcss-normalize-positions "^6.0.0"
-    postcss-normalize-repeat-style "^6.0.0"
-    postcss-normalize-string "^6.0.0"
-    postcss-normalize-timing-functions "^6.0.0"
-    postcss-normalize-unicode "^6.0.0"
-    postcss-normalize-url "^6.0.0"
-    postcss-normalize-whitespace "^6.0.0"
-    postcss-ordered-values "^6.0.0"
-    postcss-reduce-initial "^6.0.0"
-    postcss-reduce-transforms "^6.0.0"
-    postcss-svgo "^6.0.0"
-    postcss-unique-selectors "^6.0.0"
+    "css-declaration-sorter" "^6.3.1"
+    "cssnano-utils" "^4.0.0"
+    "postcss-calc" "^9.0.0"
+    "postcss-colormin" "^6.0.0"
+    "postcss-convert-values" "^6.0.0"
+    "postcss-discard-comments" "^6.0.0"
+    "postcss-discard-duplicates" "^6.0.0"
+    "postcss-discard-empty" "^6.0.0"
+    "postcss-discard-overridden" "^6.0.0"
+    "postcss-merge-longhand" "^6.0.0"
+    "postcss-merge-rules" "^6.0.1"
+    "postcss-minify-font-values" "^6.0.0"
+    "postcss-minify-gradients" "^6.0.0"
+    "postcss-minify-params" "^6.0.0"
+    "postcss-minify-selectors" "^6.0.0"
+    "postcss-normalize-charset" "^6.0.0"
+    "postcss-normalize-display-values" "^6.0.0"
+    "postcss-normalize-positions" "^6.0.0"
+    "postcss-normalize-repeat-style" "^6.0.0"
+    "postcss-normalize-string" "^6.0.0"
+    "postcss-normalize-timing-functions" "^6.0.0"
+    "postcss-normalize-unicode" "^6.0.0"
+    "postcss-normalize-url" "^6.0.0"
+    "postcss-normalize-whitespace" "^6.0.0"
+    "postcss-ordered-values" "^6.0.0"
+    "postcss-reduce-initial" "^6.0.0"
+    "postcss-reduce-transforms" "^6.0.0"
+    "postcss-svgo" "^6.0.0"
+    "postcss-unique-selectors" "^6.0.0"
 
-cssnano-utils@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-4.0.0.tgz#d1da885ec04003ab19505ff0e62e029708d36b08"
-  integrity sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==
+"cssnano-utils@^4.0.0":
+  "integrity" "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw=="
+  "resolved" "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz"
+  "version" "4.0.0"
 
-cssnano@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-6.0.1.tgz#87c38c4cd47049c735ab756d7e77ac3ca855c008"
-  integrity sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==
+"cssnano@^6.0.1":
+  "integrity" "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg=="
+  "resolved" "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz"
+  "version" "6.0.1"
   dependencies:
-    cssnano-preset-default "^6.0.1"
-    lilconfig "^2.1.0"
+    "cssnano-preset-default" "^6.0.1"
+    "lilconfig" "^2.1.0"
 
-csso@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-5.0.5.tgz#f9b7fe6cc6ac0b7d90781bb16d5e9874303e2ca6"
-  integrity sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==
+"csso@^5.0.5":
+  "integrity" "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="
+  "resolved" "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz"
+  "version" "5.0.5"
   dependencies:
-    css-tree "~2.2.0"
+    "css-tree" "~2.2.0"
 
-dom-serializer@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
-  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
+"dom-serializer@^1.0.1":
+  "integrity" "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="
+  "resolved" "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz"
+  "version" "1.4.1"
   dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
+    "domelementtype" "^2.0.1"
+    "domhandler" "^4.2.0"
+    "entities" "^2.0.0"
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
-  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+"dom-serializer@^2.0.0":
+  "integrity" "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="
+  "resolved" "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz"
+  "version" "2.0.0"
   dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.2"
+    "entities" "^4.2.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
-  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+"domelementtype@^2.0.1", "domelementtype@^2.2.0", "domelementtype@^2.3.0":
+  "integrity" "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+  "resolved" "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
+  "version" "2.3.0"
 
-domhandler@^4.2.0, domhandler@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
-  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+"domhandler@^4.2.0", "domhandler@^4.3.1":
+  "integrity" "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ=="
+  "resolved" "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz"
+  "version" "4.3.1"
   dependencies:
-    domelementtype "^2.2.0"
+    "domelementtype" "^2.2.0"
 
-domhandler@^5.0.2, domhandler@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+"domhandler@^5.0.2", "domhandler@^5.0.3":
+  "integrity" "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="
+  "resolved" "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
+  "version" "5.0.3"
   dependencies:
-    domelementtype "^2.3.0"
+    "domelementtype" "^2.3.0"
 
-domutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+"domutils@^2.8.0":
+  "integrity" "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="
+  "resolved" "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz"
+  "version" "2.8.0"
   dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
+    "dom-serializer" "^1.0.1"
+    "domelementtype" "^2.2.0"
+    "domhandler" "^4.2.0"
 
-domutils@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
-  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+"domutils@^3.0.1":
+  "integrity" "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA=="
+  "resolved" "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz"
+  "version" "3.1.0"
   dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
+    "dom-serializer" "^2.0.0"
+    "domelementtype" "^2.3.0"
+    "domhandler" "^5.0.3"
 
-dot-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
-  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+"dot-case@^3.0.4":
+  "integrity" "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="
+  "resolved" "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz"
+  "version" "3.0.4"
   dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
+    "no-case" "^3.0.4"
+    "tslib" "^2.0.3"
 
-dotenv-expand@^8.0.2:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-8.0.3.tgz#29016757455bcc748469c83a19b36aaf2b83dd6e"
-  integrity sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==
+"dotenv-expand@^8.0.2":
+  "integrity" "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg=="
+  "resolved" "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz"
+  "version" "8.0.3"
 
-dotenv@^16.0.0:
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
-  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+"dotenv@^16.0.0":
+  "integrity" "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+  "resolved" "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz"
+  "version" "16.0.3"
 
-ejs@^3.1.6:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
-  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
+"ejs@^3.1.6":
+  "integrity" "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ=="
+  "resolved" "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz"
+  "version" "3.1.9"
   dependencies:
-    jake "^10.8.5"
+    "jake" "^10.8.5"
 
-electron-to-chromium@^1.4.284:
-  version "1.4.385"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.385.tgz#1afd8d6280d510145148777b899ff481c65531ff"
-  integrity sha512-L9zlje9bIw0h+CwPQumiuVlfMcV4boxRjFIWDcLfFqTZNbkwOExBzfmswytHawObQX4OUhtNv8gIiB21kOurIg==
+"electron-to-chromium@^1.4.284":
+  "integrity" "sha512-L9zlje9bIw0h+CwPQumiuVlfMcV4boxRjFIWDcLfFqTZNbkwOExBzfmswytHawObQX4OUhtNv8gIiB21kOurIg=="
+  "resolved" "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.385.tgz"
+  "version" "1.4.385"
 
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+"entities@^2.0.0":
+  "integrity" "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+  "resolved" "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
+  "version" "2.2.0"
 
-entities@^4.2.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
-  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+"entities@^4.2.0":
+  "integrity" "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+  "resolved" "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
+  "version" "4.5.0"
 
-esbuild@^0.18.10:
-  version "0.18.20"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.20.tgz#4709f5a34801b43b799ab7d6d82f7284a9b7a7a6"
-  integrity sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==
+"esbuild@^0.18.10":
+  "integrity" "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="
+  "resolved" "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz"
+  "version" "0.18.20"
   optionalDependencies:
     "@esbuild/android-arm" "0.18.20"
     "@esbuild/android-arm64" "0.18.20"
@@ -1094,628 +989,618 @@ esbuild@^0.18.10:
     "@esbuild/win32-ia32" "0.18.20"
     "@esbuild/win32-x64" "0.18.20"
 
-escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+"escalade@^3.1.1":
+  "integrity" "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+  "resolved" "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
+  "version" "3.1.1"
 
-estree-walker@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+"estree-walker@^2.0.1":
+  "integrity" "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+  "resolved" "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz"
+  "version" "2.0.2"
 
-fast-glob@^3.2.11:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
-  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+"fast-glob@^3.2.11":
+  "integrity" "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w=="
+  "resolved" "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz"
+  "version" "3.2.12"
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
+    "glob-parent" "^5.1.2"
+    "merge2" "^1.3.0"
+    "micromatch" "^4.0.4"
 
-fastq@^1.6.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
-  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
+"fastq@^1.6.0":
+  "integrity" "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw=="
+  "resolved" "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz"
+  "version" "1.15.0"
   dependencies:
-    reusify "^1.0.4"
+    "reusify" "^1.0.4"
 
-filelist@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
-  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+"filelist@^1.0.1":
+  "integrity" "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="
+  "resolved" "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz"
+  "version" "1.0.4"
   dependencies:
-    minimatch "^5.0.1"
+    "minimatch" "^5.0.1"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+"fill-range@^7.0.1":
+  "integrity" "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ=="
+  "resolved" "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
+  "version" "7.0.1"
   dependencies:
-    to-regex-range "^5.0.1"
+    "to-regex-range" "^5.0.1"
 
-fs-extra@^10.0.1:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+"fs-extra@^10.0.1":
+  "integrity" "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="
+  "resolved" "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"
+  "version" "10.1.0"
   dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
+    "graceful-fs" "^4.2.0"
+    "jsonfile" "^6.0.1"
+    "universalify" "^2.0.0"
 
-fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
-glob-parent@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+"glob-parent@^5.1.2":
+  "integrity" "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="
+  "resolved" "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
+  "version" "5.1.2"
   dependencies:
-    is-glob "^4.0.1"
+    "is-glob" "^4.0.1"
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+"graceful-fs@^4.1.6", "graceful-fs@^4.2.0":
+  "integrity" "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+  "resolved" "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
+  "version" "4.2.11"
 
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+"has-flag@^4.0.0":
+  "integrity" "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+  "resolved" "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
+  "version" "4.0.0"
 
-he@1.2.0, he@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+"he@^1.2.0", "he@1.2.0":
+  "integrity" "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+  "resolved" "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
+  "version" "1.2.0"
 
-html-minifier-terser@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#bfc818934cc07918f6b3669f5774ecdfd48f32ab"
-  integrity sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==
+"html-minifier-terser@^6.1.0":
+  "integrity" "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw=="
+  "resolved" "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz"
+  "version" "6.1.0"
   dependencies:
-    camel-case "^4.1.2"
-    clean-css "^5.2.2"
-    commander "^8.3.0"
-    he "^1.2.0"
-    param-case "^3.0.4"
-    relateurl "^0.2.7"
-    terser "^5.10.0"
+    "camel-case" "^4.1.2"
+    "clean-css" "^5.2.2"
+    "commander" "^8.3.0"
+    "he" "^1.2.0"
+    "param-case" "^3.0.4"
+    "relateurl" "^0.2.7"
+    "terser" "^5.10.0"
 
-is-extglob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+"is-extglob@^2.1.1":
+  "integrity" "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+  "resolved" "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+  "version" "2.1.1"
 
-is-glob@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
-  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+"is-glob@^4.0.1":
+  "integrity" "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="
+  "resolved" "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
+  "version" "4.0.3"
   dependencies:
-    is-extglob "^2.1.1"
+    "is-extglob" "^2.1.1"
 
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
-  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+"is-number@^7.0.0":
+  "integrity" "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+  "resolved" "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
+  "version" "7.0.0"
 
-jake@^10.8.5:
-  version "10.8.5"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
-  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+"jake@^10.8.5":
+  "integrity" "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw=="
+  "resolved" "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz"
+  "version" "10.8.5"
   dependencies:
-    async "^3.2.3"
-    chalk "^4.0.2"
-    filelist "^1.0.1"
-    minimatch "^3.0.4"
+    "async" "^3.2.3"
+    "chalk" "^4.0.2"
+    "filelist" "^1.0.1"
+    "minimatch" "^3.0.4"
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+"jsonfile@^6.0.1":
+  "integrity" "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="
+  "resolved" "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz"
+  "version" "6.1.0"
   dependencies:
-    universalify "^2.0.0"
+    "universalify" "^2.0.0"
   optionalDependencies:
-    graceful-fs "^4.1.6"
+    "graceful-fs" "^4.1.6"
 
-lilconfig@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
-  integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
+"lilconfig@^2.1.0":
+  "integrity" "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
+  "resolved" "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz"
+  "version" "2.1.0"
 
-lodash.memoize@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+"lodash.memoize@^4.1.2":
+  "integrity" "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="
+  "resolved" "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+  "version" "4.1.2"
 
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
+"lodash.uniq@^4.5.0":
+  "integrity" "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+  "resolved" "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+  "version" "4.5.0"
 
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+"lower-case@^2.0.2":
+  "integrity" "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="
+  "resolved" "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz"
+  "version" "2.0.2"
   dependencies:
-    tslib "^2.0.3"
+    "tslib" "^2.0.3"
 
-mdn-data@2.0.28:
-  version "2.0.28"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
-  integrity sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==
+"mdn-data@2.0.28":
+  "integrity" "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
+  "resolved" "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz"
+  "version" "2.0.28"
 
-mdn-data@2.0.30:
-  version "2.0.30"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
-  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+"mdn-data@2.0.30":
+  "integrity" "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+  "resolved" "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz"
+  "version" "2.0.30"
 
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+"merge2@^1.3.0":
+  "integrity" "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+  "resolved" "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
+  "version" "1.4.1"
 
-micromatch@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+"micromatch@^4.0.4":
+  "integrity" "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA=="
+  "resolved" "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz"
+  "version" "4.0.5"
   dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
+    "braces" "^3.0.2"
+    "picomatch" "^2.3.1"
 
-minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+"minimatch@^3.0.4":
+  "integrity" "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="
+  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
+  "version" "3.1.2"
   dependencies:
-    brace-expansion "^1.1.7"
+    "brace-expansion" "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+"minimatch@^5.0.1":
+  "integrity" "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="
+  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz"
+  "version" "5.1.6"
   dependencies:
-    brace-expansion "^2.0.1"
+    "brace-expansion" "^2.0.1"
 
-nanoid@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
-  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+"nanoid@^3.3.6":
+  "integrity" "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+  "resolved" "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz"
+  "version" "3.3.6"
 
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+"no-case@^3.0.4":
+  "integrity" "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="
+  "resolved" "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz"
+  "version" "3.0.4"
   dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
+    "lower-case" "^2.0.2"
+    "tslib" "^2.0.3"
 
-node-html-parser@^5.3.3:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-5.4.2.tgz#93e004038c17af80226c942336990a0eaed8136a"
-  integrity sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw==
+"node-html-parser@^5.3.3":
+  "integrity" "sha512-RaBPP3+51hPne/OolXxcz89iYvQvKOydaqoePpOgXcrOKZhjVIzmpKZz+Hd/RBO2/zN2q6CNJhQzucVz+u3Jyw=="
+  "resolved" "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.4.2.tgz"
+  "version" "5.4.2"
   dependencies:
-    css-select "^4.2.1"
-    he "1.2.0"
+    "css-select" "^4.2.1"
+    "he" "1.2.0"
 
-node-releases@^2.0.8:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
-  integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
+"node-releases@^2.0.8":
+  "integrity" "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
+  "resolved" "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz"
+  "version" "2.0.10"
 
-nth-check@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
-  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+"nth-check@^2.0.1":
+  "integrity" "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="
+  "resolved" "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
+  "version" "2.1.1"
   dependencies:
-    boolbase "^1.0.0"
+    "boolbase" "^1.0.0"
 
-param-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
-  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
+"param-case@^3.0.4":
+  "integrity" "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A=="
+  "resolved" "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz"
+  "version" "3.0.4"
   dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
+    "dot-case" "^3.0.4"
+    "tslib" "^2.0.3"
 
-pascal-case@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
-  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+"pascal-case@^3.1.2":
+  "integrity" "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g=="
+  "resolved" "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz"
+  "version" "3.1.2"
   dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
+    "no-case" "^3.0.4"
+    "tslib" "^2.0.3"
 
-pathe@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-0.2.0.tgz#30fd7bbe0a0d91f0e60bae621f5d19e9e225c339"
-  integrity sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==
+"pathe@^0.2.0":
+  "integrity" "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw=="
+  "resolved" "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz"
+  "version" "0.2.0"
 
-picocolors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
-  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+"picocolors@^1.0.0":
+  "integrity" "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+  "resolved" "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
+  "version" "1.0.0"
 
-picomatch@^2.2.2, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+"picomatch@^2.2.2", "picomatch@^2.3.1":
+  "integrity" "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+  "resolved" "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
+  "version" "2.3.1"
 
-postcss-calc@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-9.0.1.tgz#a744fd592438a93d6de0f1434c572670361eb6c6"
-  integrity sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==
+"postcss-calc@^9.0.0":
+  "integrity" "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ=="
+  "resolved" "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz"
+  "version" "9.0.1"
   dependencies:
-    postcss-selector-parser "^6.0.11"
-    postcss-value-parser "^4.2.0"
+    "postcss-selector-parser" "^6.0.11"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-colormin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-6.0.0.tgz#d4250652e952e1c0aca70c66942da93d3cdeaafe"
-  integrity sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==
+"postcss-colormin@^6.0.0":
+  "integrity" "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw=="
+  "resolved" "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    browserslist "^4.21.4"
-    caniuse-api "^3.0.0"
-    colord "^2.9.1"
-    postcss-value-parser "^4.2.0"
+    "browserslist" "^4.21.4"
+    "caniuse-api" "^3.0.0"
+    "colord" "^2.9.1"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-convert-values@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz#ec94a954957e5c3f78f0e8f65dfcda95280b8996"
-  integrity sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==
+"postcss-convert-values@^6.0.0":
+  "integrity" "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw=="
+  "resolved" "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    browserslist "^4.21.4"
-    postcss-value-parser "^4.2.0"
+    "browserslist" "^4.21.4"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-discard-comments@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz#9ca335e8b68919f301b24ba47dde226a42e535fe"
-  integrity sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==
+"postcss-discard-comments@^6.0.0":
+  "integrity" "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw=="
+  "resolved" "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz"
+  "version" "6.0.0"
 
-postcss-discard-duplicates@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz#c26177a6c33070922e67e9a92c0fd23d443d1355"
-  integrity sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==
+"postcss-discard-duplicates@^6.0.0":
+  "integrity" "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA=="
+  "resolved" "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz"
+  "version" "6.0.0"
 
-postcss-discard-empty@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz#06c1c4fce09e22d2a99e667c8550eb8a3a1b9aee"
-  integrity sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==
+"postcss-discard-empty@^6.0.0":
+  "integrity" "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ=="
+  "resolved" "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz"
+  "version" "6.0.0"
 
-postcss-discard-overridden@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz#49c5262db14e975e349692d9024442de7cd8e234"
-  integrity sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==
+"postcss-discard-overridden@^6.0.0":
+  "integrity" "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw=="
+  "resolved" "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz"
+  "version" "6.0.0"
 
-postcss-merge-longhand@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz#6f627b27db939bce316eaa97e22400267e798d69"
-  integrity sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==
+"postcss-merge-longhand@^6.0.0":
+  "integrity" "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg=="
+  "resolved" "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
-    stylehacks "^6.0.0"
+    "postcss-value-parser" "^4.2.0"
+    "stylehacks" "^6.0.0"
 
-postcss-merge-rules@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz#39f165746404e646c0f5c510222ccde4824a86aa"
-  integrity sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==
+"postcss-merge-rules@^6.0.1":
+  "integrity" "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw=="
+  "resolved" "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz"
+  "version" "6.0.1"
   dependencies:
-    browserslist "^4.21.4"
-    caniuse-api "^3.0.0"
-    cssnano-utils "^4.0.0"
-    postcss-selector-parser "^6.0.5"
+    "browserslist" "^4.21.4"
+    "caniuse-api" "^3.0.0"
+    "cssnano-utils" "^4.0.0"
+    "postcss-selector-parser" "^6.0.5"
 
-postcss-minify-font-values@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz#68d4a028f9fa5f61701974724b2cc9445d8e6070"
-  integrity sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==
+"postcss-minify-font-values@^6.0.0":
+  "integrity" "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA=="
+  "resolved" "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-minify-gradients@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz#22b5c88cc63091dadbad34e31ff958404d51d679"
-  integrity sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==
+"postcss-minify-gradients@^6.0.0":
+  "integrity" "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA=="
+  "resolved" "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    colord "^2.9.1"
-    cssnano-utils "^4.0.0"
-    postcss-value-parser "^4.2.0"
+    "colord" "^2.9.1"
+    "cssnano-utils" "^4.0.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-minify-params@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz#2b3a85a9e3b990d7a16866f430f5fd1d5961b539"
-  integrity sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==
+"postcss-minify-params@^6.0.0":
+  "integrity" "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ=="
+  "resolved" "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    browserslist "^4.21.4"
-    cssnano-utils "^4.0.0"
-    postcss-value-parser "^4.2.0"
+    "browserslist" "^4.21.4"
+    "cssnano-utils" "^4.0.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-minify-selectors@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz#5046c5e8680a586e5a0cad52cc9aa36d6be5bda2"
-  integrity sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==
+"postcss-minify-selectors@^6.0.0":
+  "integrity" "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g=="
+  "resolved" "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-selector-parser "^6.0.5"
+    "postcss-selector-parser" "^6.0.5"
 
-postcss-normalize-charset@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz#36cc12457259064969fb96f84df491652a4b0975"
-  integrity sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==
+"postcss-normalize-charset@^6.0.0":
+  "integrity" "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz"
+  "version" "6.0.0"
 
-postcss-normalize-display-values@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz#8d2961415078644d8c6bbbdaf9a2fdd60f546cd4"
-  integrity sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==
+"postcss-normalize-display-values@^6.0.0":
+  "integrity" "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-positions@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz#25b96df99a69f8925f730eaee0be74416865e301"
-  integrity sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==
+"postcss-normalize-positions@^6.0.0":
+  "integrity" "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-repeat-style@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz#ddf30ad8762feb5b1eb97f39f251acd7b8353299"
-  integrity sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==
+"postcss-normalize-repeat-style@^6.0.0":
+  "integrity" "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-string@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz#948282647a51e409d69dde7910f0ac2ff97cb5d8"
-  integrity sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==
+"postcss-normalize-string@^6.0.0":
+  "integrity" "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-timing-functions@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz#5f13e650b8c43351989fc5de694525cc2539841c"
-  integrity sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==
+"postcss-normalize-timing-functions@^6.0.0":
+  "integrity" "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-unicode@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz#741b3310f874616bdcf07764f5503695d3604730"
-  integrity sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==
+"postcss-normalize-unicode@^6.0.0":
+  "integrity" "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    browserslist "^4.21.4"
-    postcss-value-parser "^4.2.0"
+    "browserslist" "^4.21.4"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-url@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz#d0a31e962a16401fb7deb7754b397a323fb650b4"
-  integrity sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==
+"postcss-normalize-url@^6.0.0":
+  "integrity" "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-normalize-whitespace@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz#accb961caa42e25ca4179b60855b79b1f7129d4d"
-  integrity sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==
+"postcss-normalize-whitespace@^6.0.0":
+  "integrity" "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw=="
+  "resolved" "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-ordered-values@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz#374704cdff25560d44061d17ba3c6308837a3218"
-  integrity sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==
+"postcss-ordered-values@^6.0.0":
+  "integrity" "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg=="
+  "resolved" "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    cssnano-utils "^4.0.0"
-    postcss-value-parser "^4.2.0"
+    "cssnano-utils" "^4.0.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-reduce-initial@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz#7d16e83e60e27e2fa42f56ec0b426f1da332eca7"
-  integrity sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==
+"postcss-reduce-initial@^6.0.0":
+  "integrity" "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA=="
+  "resolved" "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    browserslist "^4.21.4"
-    caniuse-api "^3.0.0"
+    "browserslist" "^4.21.4"
+    "caniuse-api" "^3.0.0"
 
-postcss-reduce-transforms@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz#28ff2601a6d9b96a2f039b3501526e1f4d584a46"
-  integrity sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==
+"postcss-reduce-transforms@^6.0.0":
+  "integrity" "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w=="
+  "resolved" "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
+    "postcss-value-parser" "^4.2.0"
 
-postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
-  version "6.0.12"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz#2efae5ffab3c8bfb2b7fbf0c426e3bca616c4abb"
-  integrity sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==
+"postcss-selector-parser@^6.0.11", "postcss-selector-parser@^6.0.4", "postcss-selector-parser@^6.0.5":
+  "integrity" "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg=="
+  "resolved" "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz"
+  "version" "6.0.12"
   dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
+    "cssesc" "^3.0.0"
+    "util-deprecate" "^1.0.2"
 
-postcss-svgo@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-6.0.0.tgz#7b18742d38d4505a0455bbe70d52b49f00eaf69d"
-  integrity sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==
+"postcss-svgo@^6.0.0":
+  "integrity" "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw=="
+  "resolved" "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-value-parser "^4.2.0"
-    svgo "^3.0.2"
+    "postcss-value-parser" "^4.2.0"
+    "svgo" "^3.0.2"
 
-postcss-unique-selectors@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz#c94e9b0f7bffb1203894e42294b5a1b3fb34fbe1"
-  integrity sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==
+"postcss-unique-selectors@^6.0.0":
+  "integrity" "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw=="
+  "resolved" "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    postcss-selector-parser "^6.0.5"
+    "postcss-selector-parser" "^6.0.5"
 
-postcss-value-parser@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
-  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+"postcss-value-parser@^4.2.0":
+  "integrity" "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+  "resolved" "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
+  "version" "4.2.0"
 
-postcss@^8.4.27:
-  version "8.4.30"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.30.tgz#0e0648d551a606ef2192a26da4cabafcc09c1aa7"
-  integrity sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==
+"postcss@^8.0.9", "postcss@^8.2.15", "postcss@^8.2.2", "postcss@^8.4.27":
+  "integrity" "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="
+  "resolved" "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
+  "version" "8.4.31"
   dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
+    "nanoid" "^3.3.6"
+    "picocolors" "^1.0.0"
+    "source-map-js" "^1.0.2"
 
-queue-microtask@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
-  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+"queue-microtask@^1.2.2":
+  "integrity" "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+  "resolved" "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
+  "version" "1.2.3"
 
-relateurl@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
-  integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+"relateurl@^0.2.7":
+  "integrity" "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
+  "resolved" "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
+  "version" "0.2.7"
 
-reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+"reusify@^1.0.4":
+  "integrity" "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+  "resolved" "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
+  "version" "1.0.4"
 
-rollup@^3.27.1:
-  version "3.29.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.3.tgz#97769774ccaa6a3059083d4680fcabd8ead01289"
-  integrity sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg==
+"rollup@^3.27.1":
+  "integrity" "sha512-T7du6Hum8jOkSWetjRgbwpM6Sy0nECYrYRSmZjayFcOddtKJWU4d17AC3HNUk7HRuqy4p+G7aEZclSHytqUmEg=="
+  "resolved" "https://registry.npmjs.org/rollup/-/rollup-3.29.3.tgz"
+  "version" "3.29.3"
   optionalDependencies:
-    fsevents "~2.3.2"
+    "fsevents" "~2.3.2"
 
-run-parallel@^1.1.9:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
-  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+"run-parallel@^1.1.9":
+  "integrity" "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="
+  "resolved" "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
+  "version" "1.2.0"
   dependencies:
-    queue-microtask "^1.2.2"
+    "queue-microtask" "^1.2.2"
 
-source-map-js@^1.0.1, source-map-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+"source-map-js@^1.0.1", "source-map-js@^1.0.2":
+  "integrity" "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+  "resolved" "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz"
+  "version" "1.0.2"
 
-source-map-support@~0.5.20:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+"source-map-support@~0.5.20":
+  "integrity" "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="
+  "resolved" "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
+  "version" "0.5.21"
   dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
+    "buffer-from" "^1.0.0"
+    "source-map" "^0.6.0"
 
-source-map@^0.6.0, source-map@~0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+"source-map@^0.6.0", "source-map@~0.6.0":
+  "integrity" "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+  "resolved" "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  "version" "0.6.1"
 
-stylehacks@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-6.0.0.tgz#9fdd7c217660dae0f62e14d51c89f6c01b3cb738"
-  integrity sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==
+"stylehacks@^6.0.0":
+  "integrity" "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw=="
+  "resolved" "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz"
+  "version" "6.0.0"
   dependencies:
-    browserslist "^4.21.4"
-    postcss-selector-parser "^6.0.4"
+    "browserslist" "^4.21.4"
+    "postcss-selector-parser" "^6.0.4"
 
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+"supports-color@^7.1.0":
+  "integrity" "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="
+  "resolved" "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  "version" "7.2.0"
   dependencies:
-    has-flag "^4.0.0"
+    "has-flag" "^4.0.0"
 
-svgo@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.2.tgz#5e99eeea42c68ee0dc46aa16da093838c262fe0a"
-  integrity sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==
+"svgo@^3.0.2":
+  "integrity" "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ=="
+  "resolved" "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz"
+  "version" "3.0.2"
   dependencies:
     "@trysound/sax" "0.2.0"
-    commander "^7.2.0"
-    css-select "^5.1.0"
-    css-tree "^2.2.1"
-    csso "^5.0.5"
-    picocolors "^1.0.0"
+    "commander" "^7.2.0"
+    "css-select" "^5.1.0"
+    "css-tree" "^2.2.1"
+    "csso" "^5.0.5"
+    "picocolors" "^1.0.0"
 
-terser@^5.10.0:
-  version "5.17.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.1.tgz#948f10830454761e2eeedc6debe45c532c83fd69"
-  integrity sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==
+"terser@^5.10.0", "terser@^5.4.0":
+  "integrity" "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw=="
+  "resolved" "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz"
+  "version" "5.17.1"
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
-    acorn "^8.5.0"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
+    "acorn" "^8.5.0"
+    "commander" "^2.20.0"
+    "source-map-support" "~0.5.20"
 
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
-  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+"to-regex-range@^5.0.1":
+  "integrity" "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="
+  "resolved" "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
+  "version" "5.0.1"
   dependencies:
-    is-number "^7.0.0"
+    "is-number" "^7.0.0"
 
-tslib@^2.0.3:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+"tslib@^2.0.3", "tslib@^2.6.2":
+  "integrity" "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+  "resolved" "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
+  "version" "2.6.2"
 
-tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+"typescript@^5.2.2":
+  "integrity" "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+  "resolved" "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
+  "version" "5.2.2"
 
-typescript@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+"undici-types@~5.26.4":
+  "integrity" "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+  "resolved" "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
+  "version" "5.26.5"
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+"universalify@^2.0.0":
+  "integrity" "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+  "resolved" "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz"
+  "version" "2.0.0"
 
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
-
-update-browserslist-db@^1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
-  integrity sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==
+"update-browserslist-db@^1.0.10":
+  "integrity" "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA=="
+  "resolved" "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz"
+  "version" "1.0.11"
   dependencies:
-    escalade "^3.1.1"
-    picocolors "^1.0.0"
+    "escalade" "^3.1.1"
+    "picocolors" "^1.0.0"
 
-util-deprecate@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+"util-deprecate@^1.0.2":
+  "integrity" "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+  "resolved" "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  "version" "1.0.2"
 
-vite-plugin-html@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/vite-plugin-html/-/vite-plugin-html-3.2.0.tgz#0d4df9900642a321a139f1c25c05195ba9d0ec79"
-  integrity sha512-2VLCeDiHmV/BqqNn5h2V+4280KRgQzCFN47cst3WiNK848klESPQnzuC3okH5XHtgwHH/6s1Ho/YV6yIO0pgoQ==
+"vite-plugin-html@^3.2.0":
+  "integrity" "sha512-2VLCeDiHmV/BqqNn5h2V+4280KRgQzCFN47cst3WiNK848klESPQnzuC3okH5XHtgwHH/6s1Ho/YV6yIO0pgoQ=="
+  "resolved" "https://registry.npmjs.org/vite-plugin-html/-/vite-plugin-html-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
     "@rollup/pluginutils" "^4.2.0"
-    colorette "^2.0.16"
-    connect-history-api-fallback "^1.6.0"
-    consola "^2.15.3"
-    dotenv "^16.0.0"
-    dotenv-expand "^8.0.2"
-    ejs "^3.1.6"
-    fast-glob "^3.2.11"
-    fs-extra "^10.0.1"
-    html-minifier-terser "^6.1.0"
-    node-html-parser "^5.3.3"
-    pathe "^0.2.0"
+    "colorette" "^2.0.16"
+    "connect-history-api-fallback" "^1.6.0"
+    "consola" "^2.15.3"
+    "dotenv" "^16.0.0"
+    "dotenv-expand" "^8.0.2"
+    "ejs" "^3.1.6"
+    "fast-glob" "^3.2.11"
+    "fs-extra" "^10.0.1"
+    "html-minifier-terser" "^6.1.0"
+    "node-html-parser" "^5.3.3"
+    "pathe" "^0.2.0"
 
-vite@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.0.tgz#ec406295b4167ac3bc23e26f9c8ff559287cff26"
-  integrity sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==
+"vite@^4.5.0", "vite@>=2.0.0":
+  "integrity" "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw=="
+  "resolved" "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz"
+  "version" "4.5.0"
   dependencies:
-    esbuild "^0.18.10"
-    postcss "^8.4.27"
-    rollup "^3.27.1"
+    "esbuild" "^0.18.10"
+    "postcss" "^8.4.27"
+    "rollup" "^3.27.1"
   optionalDependencies:
-    fsevents "~2.3.2"
+    "fsevents" "~2.3.2"


### PR DESCRIPTION
- Replace the old fxhash snippet in `index.html` by a reference to the new SDK as a standalone file. The new file is under the `public` folder so that `vite` doesn't do any transform on it (it needs to stay identical so fxhash can validate it when trying to upload a generative token) but still include it in the dist.
- Upgrade version of `@thi.ng/random-fxhash` to `0.3.18` that supports the new SDK
- Update `vite build` command to omit the extra single quotes
- Add new `fxhash.js` to the `bundle` command so it gets zipped (couldn't test that one as I'm on Windows)
- Update documentation to reference which version is used