### PR TITLE
Use @fxhash/project-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"vite-plugin-html": "^3.2.2"
 	},
 	"dependencies": {
+		"@fxhash/project-sdk": "0.0.13",
 		"@thi.ng/canvas": "^0.1.1",
 		"@thi.ng/date": "^2.5.8",
 		"@thi.ng/dl-asset": "^2.3.54",

--- a/src/api.ts
+++ b/src/api.ts
@@ -116,36 +116,3 @@ export interface State extends BaseState {
 	 */
 	canvas: CanvasContext;
 }
-
-
-/**
- * Some useful variables and function from the @fxhash/project-sdk
- * Will be exposed in window.$fx
- * 
- * @remarks
- * Reference:
- * https://fxhash-documentation.super.site/480dd683bdb447ec8a20eeacbe320188
- */ 
-export interface FxProjectSDK {
-  /** 
-  * A random 64 characters hexadecimal string. This particular variable will be 
-  * hardcoded with a static hash when someone mints a token from your GT
-  */
-  hash: string,
-  /**
-   * trigger for capture module
-   */ 
-  preview: () => void,
-  /**
-   * is TRUE when capture module is running the project
-   */ 
-  isPreview: boolean,
-  /**
-   * sets your projects features
-   */ 
-  features: (features: any) => void,
-  /**
-   * get all features
-   */
-  getFeatures: () => any
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,10 @@ import {
 	warpPoints,
 } from "@thi.ng/geom";
 import { draw } from "@thi.ng/hiccup-canvas";
-import type { FxProjectSDK, State } from "./api";
+import "@fxhash/project-sdk";
+import type { State } from "./api";
 import { resolveState } from "./state";
 
-// these declarations ensure TypeScript is aware of these
-// externally defined vars/functions
-declare global {
-  interface Window {
-    $fx: FxProjectSDK
-  }
-}
 // flag to guard code blocks which are only wanted during development
 // any `if (DEBUG) { ... }` code blocks will be removed in production builds
 const DEBUG = process.env.NODE_ENV !== "production";


### PR DESCRIPTION
`@fxhash/project-sdk` defines [a global `window.$fx`](https://github.com/fxhash/fxhash-package/blob/49f8967473c0c3a49e53cbf50aece31bd6ce28d3/packages/project-sdk/src/types.ts#L50) which can be used throughout the project so long as it’s imported somewhere.

I added `@fxhash/project-sdk` to `dependencies`, but it may belong in `devDependencies`, I’m not sure.

As discussed in #2